### PR TITLE
fix: stream actWithTools rounds to prevent tool timeout and double mo…

### DIFF
--- a/src/providers/llm/CLAUDE.md
+++ b/src/providers/llm/CLAUDE.md
@@ -102,13 +102,11 @@ new OllamaProvider(
 | `"native"` | Sends tools in OpenAI format; drives a manual agentic loop checking `tool_calls` on each response | Models with Ollama tool support (llama3, mistral, etc.) |
 | `"structured_output"` | Uses `buildToolSystemPromptAddition` + Ollama `format` (JSON schema) to constrain output | Any model that doesn't support native tools |
 
-**Reasoning extraction:** Ollama has no SDK-level reasoning markers. `parseStreamChunk()` manually detects `<think>...</think>` tags across streaming chunk boundaries:
-- Content inside `<think>...</think>` → `reasoningText`, streamed with `isReasoning: true`
-- All other content → `nonReasoningContent`, streamed with `isReasoning: false`
+**Reasoning extraction:** Ollama surfaces reasoning in `message.thinking` and the response in `message.content` as separate fields — no tag parsing needed. Chunks where `message.thinking` is set are emitted with `isReasoning: true`; chunks where `message.content` is set are emitted with `isReasoning: false`.
 
 **`numCtx` — optional:** Ollama automatically scales context length based on available system resources. Set `numCtx` only if you need to cap or guarantee a specific size.
 
-**Native tool-call loop:** `actWithTools()` runs up to 10 rounds. Each round sends the full message history with tools; if the response has `tool_calls`, executes them and appends `{ role: "tool", content }` messages before the next round. The final round with no `tool_calls` is returned as the response.
+**Native tool-call loop:** `actWithTools()` runs up to 100 rounds. Each round streams the full message history with tools, collecting chunks silently. If the accumulated response has `tool_calls`, executes them and appends `{ role: "tool", content }` messages before the next round. The final round with no `tool_calls` emits the collected thinking and content to `onToken` and returns directly — the model is not re-invoked.
 
 ## Gotchas
 

--- a/src/providers/llm/OllamaProvider.ts
+++ b/src/providers/llm/OllamaProvider.ts
@@ -184,26 +184,53 @@ export class OllamaProvider implements LLMProvider {
     const history = [...messages];
 
     for (let round = 0; round < MAX_ROUNDS; round++) {
-      const response = await this.client.chat({
+      // Stream to keep the connection alive during long tool executions.
+      // We must collect silently — tool_calls only appear on the final chunk,
+      // so we cannot know whether to emit tokens until the stream is complete.
+      const stream = await this.client.chat({
         model: this.model,
         messages: history,
         tools: ollamaTools,
-        stream: false,
+        stream: true,
         think: this.think,
         ...(this.numCtx !== undefined
           ? { options: { num_ctx: this.numCtx } }
           : {}),
       });
 
-      const assistantMsg = response.message;
+      let roundThinking = "";
+      let roundContent = "";
+      let toolCalls: OllamaMessage["tool_calls"] | undefined;
 
-      if (!assistantMsg.tool_calls || assistantMsg.tool_calls.length === 0) {
+      for await (const chunk of stream) {
+        if (chunk.message.thinking) roundThinking += chunk.message.thinking;
+        if (chunk.message.content) roundContent += chunk.message.content;
+        if (chunk.message.tool_calls?.length) toolCalls = chunk.message.tool_calls;
+      }
+
+      if (!toolCalls || toolCalls.length === 0) {
+        // Final round: emit what we collected and return directly.
+        // Do NOT call respond() — re-invoking the model a second time was the
+        // root cause of "shows thinking but no content" bugs in past fix attempts.
         logger.debug(
           "Ollama",
           `actWithTools() finished after ${round + 1} round(s)`,
         );
-        return await this.respond(history, onToken);
+        if (roundThinking) onToken?.(roundThinking, true);
+        if (roundContent) onToken?.(roundContent, false);
+        return {
+          response: roundContent || roundThinking,
+          nonReasoningContent: roundContent,
+          reasoningText: roundThinking,
+        };
       }
+
+      const assistantMsg: OllamaMessage = {
+        role: "assistant",
+        content: roundContent,
+        thinking: roundThinking || undefined,
+        tool_calls: toolCalls,
+      };
 
       history.push(assistantMsg);
 


### PR DESCRIPTION
…del call

Replaces stream:false with stream:true in the actWithTools loop, collecting chunks silently each round. On the final round (no tool_calls), emits the collected tokens directly instead of calling respond() — which was re-invoking the model a second time and was the root cause of "shows thinking but no content" bugs in past fix attempts. Also corrects stale CLAUDE.md docs (10→100 rounds, <think> tag parsing → message.thinking field).