### PR TITLE
feat: add active goal system to ScratchPlugin for multi-turn task per…

### DIFF
--- a/2b.ts
+++ b/2b.ts
@@ -100,6 +100,8 @@ const systemPrompt = [
   'Use "headless" for isolated one-shot tasks. Use "cortex" when the agent needs to remember context across multiple calls.',
   "",
   "The explore_codebase tool is separate — use it to read and understand this agent's own source code.",
+  "",
+  "Multi-turn tasks: When the user gives you a task that spans multiple turns (e.g. 'ask me questions about X for 20 turns', 'work through this list one item at a time'), call set_active_goal immediately with a description of the task and any progress tracking. This pins the goal into every system prompt for the session so it survives message summarization. Call clear_active_goal when the task is finished.",
 ].join("\n");
 
 const agent = new CortexAgent(llm, {

--- a/src/plugins/ScratchPlugin.test.ts
+++ b/src/plugins/ScratchPlugin.test.ts
@@ -170,6 +170,61 @@ describe("getContext", () => {
   });
 });
 
+// ── active goal ───────────────────────────────────────────────────────────────
+
+describe("active goal", () => {
+  test("get_active_goal returns null when no goal is set", async () => {
+    const result = (await plugin.executeTool("get_active_goal", {})) as any;
+    expect(result.goal).toBeNull();
+  });
+
+  test("set_active_goal stores the goal and returns it", async () => {
+    const result = (await plugin.executeTool("set_active_goal", { goal: "Ask user 20 questions about TypeScript" })) as any;
+    expect(result.ok).toBe(true);
+    expect(result.goal).toBe("Ask user 20 questions about TypeScript");
+  });
+
+  test("get_active_goal returns the stored goal after set", async () => {
+    await plugin.executeTool("set_active_goal", { goal: "Work through 10 items one at a time" });
+    const result = (await plugin.executeTool("get_active_goal", {})) as any;
+    expect(result.goal).toBe("Work through 10 items one at a time");
+  });
+
+  test("set_active_goal overwrites a previous goal", async () => {
+    await plugin.executeTool("set_active_goal", { goal: "First goal" });
+    await plugin.executeTool("set_active_goal", { goal: "Updated goal with progress: item 3 of 10" });
+    const result = (await plugin.executeTool("get_active_goal", {})) as any;
+    expect(result.goal).toBe("Updated goal with progress: item 3 of 10");
+  });
+
+  test("clear_active_goal removes the goal", async () => {
+    await plugin.executeTool("set_active_goal", { goal: "Some task" });
+    const cleared = (await plugin.executeTool("clear_active_goal", {})) as any;
+    expect(cleared.ok).toBe(true);
+    const result = (await plugin.executeTool("get_active_goal", {})) as any;
+    expect(result.goal).toBeNull();
+  });
+
+  test("getSystemPromptFragment includes active goal when set", async () => {
+    await plugin.executeTool("set_active_goal", { goal: "Ask 20 questions about X" });
+    const fragment = plugin.getSystemPromptFragment();
+    expect(fragment).toContain("Active Goal");
+    expect(fragment).toContain("Ask 20 questions about X");
+  });
+
+  test("getSystemPromptFragment omits Active Goal section when no goal is set", async () => {
+    const fragment = plugin.getSystemPromptFragment();
+    expect(fragment).not.toContain("Active Goal");
+  });
+
+  test("getSystemPromptFragment omits Active Goal section after clear", async () => {
+    await plugin.executeTool("set_active_goal", { goal: "Some task" });
+    await plugin.executeTool("clear_active_goal", {});
+    const fragment = plugin.getSystemPromptFragment();
+    expect(fragment).not.toContain("Active Goal");
+  });
+});
+
 // ── unknown tool ──────────────────────────────────────────────────────────────
 
 describe("unknown tool", () => {

--- a/src/plugins/ScratchPlugin.ts
+++ b/src/plugins/ScratchPlugin.ts
@@ -36,6 +36,7 @@ export class ScratchPlugin implements AgentPlugin {
 
   readonly sessionDir: string;
   private initialized = false;
+  private activeGoal: string | null = null;
 
   constructor(sessionId?: string) {
     this.sessionDir = join(tmpdir(), `agent-${sessionId ?? randomUUID()}`);
@@ -58,14 +59,28 @@ export class ScratchPlugin implements AgentPlugin {
   }
 
   getSystemPromptFragment(): string {
-    return [
+    const parts: string[] = [];
+
+    if (this.activeGoal !== null) {
+      parts.push(
+        "## Active Goal",
+        "You are currently committed to the following task. Continue pursuing it until it is complete or you are explicitly told to stop.",
+        this.activeGoal,
+        "Use clear_active_goal when the task is finished.",
+      );
+    }
+
+    parts.push(
       "You have a scratch pad for saving content you may need to retrieve verbatim in a future turn.",
       "- scratch_write: Save text under a short descriptive name (e.g. 'auth-middleware', 'api-schema', 'refactor-plan').",
       "- scratch_read: Retrieve saved content in full.",
       "- scratch_list: List all saved scratch files with their sizes.",
       "- scratch_delete: Remove a scratch file you no longer need.",
       "IMPORTANT: Before generating substantial content — code, plans, analysis, long outputs — that you may need to reference verbatim in a future turn, save it with scratch_write. Do not rely on conversation history to preserve full content after summarization.",
-    ].join("\n");
+      "When the user gives you a multi-turn task (e.g. 'ask me questions about X for 20 turns', 'work through this list one item per message'), call set_active_goal immediately with a clear description of the task and any progress tracking needed. This survives message summarization.",
+    );
+
+    return parts.join("\n");
   }
 
   async getContext(): Promise<string> {
@@ -150,6 +165,41 @@ export class ScratchPlugin implements AgentPlugin {
           required: ["name"],
         },
       },
+      {
+        name: "set_active_goal",
+        description:
+          "Pin a multi-turn task as the active goal. The goal is injected into every system prompt for the rest of the session, surviving message summarization. Use this immediately when the user gives you a task that spans multiple turns (e.g. 'ask me 20 questions', 'work through this list'). Include any progress tracking in the goal text (e.g. 'Question 3 of 20'). Call clear_active_goal when done.",
+        parameters: {
+          type: "object",
+          properties: {
+            goal: {
+              type: "string",
+              description: "Description of the task and any progress state to track.",
+            },
+          },
+          required: ["goal"],
+        },
+      },
+      {
+        name: "get_active_goal",
+        description: "Return the current active goal, or null if none is set.",
+        parameters: {
+          type: "object",
+          properties: {},
+          required: [],
+          additionalProperties: false,
+        },
+      },
+      {
+        name: "clear_active_goal",
+        description: "Clear the active goal once the task is complete.",
+        parameters: {
+          type: "object",
+          properties: {},
+          required: [],
+          additionalProperties: false,
+        },
+      },
     ];
   }
 
@@ -175,6 +225,16 @@ export class ScratchPlugin implements AgentPlugin {
           SCRATCH_OP_TIMEOUT_MS,
           "scratch_delete",
         );
+      case "set_active_goal":
+        this.activeGoal = String(args.goal ?? "");
+        logger.debug("Scratch", `set_active_goal: "${this.activeGoal.slice(0, 80)}"`);
+        return { ok: true, goal: this.activeGoal };
+      case "get_active_goal":
+        return { goal: this.activeGoal };
+      case "clear_active_goal":
+        this.activeGoal = null;
+        logger.debug("Scratch", "clear_active_goal");
+        return { ok: true };
       default:
         return undefined;
     }


### PR DESCRIPTION
…sistence

Adds set_active_goal/get_active_goal/clear_active_goal tools to ScratchPlugin. The active goal is stored in memory (no SQLite, no file) and injected into the system prompt fragment every turn, surviving message summarization without polluting long-term behavior memories.