### PR TITLE
docs: add inline JSDoc across all critical code paths

### DIFF
--- a/2b.ts
+++ b/2b.ts
@@ -2,7 +2,18 @@
 /**
  * Entry point for the 2b agent.
  *
- * Defines the agent, registers plugins, then hands off to the terminal UI.
+ * Parses CLI flags, constructs the LLM provider and CortexAgent, registers all
+ * plugins in dependency order, then delegates to either the terminal or web UI.
+ *
+ * Depends on:
+ *   - MODEL env var (overridden by --model flag) — LMStudio model identifier
+ *   - PORT env var (overridden by --port flag) — web UI port, default 3000
+ *   - DEBUG_TOKENS env var or --debug-tokens flag — streams raw tokens to stdout
+ *
+ * Critical: this is the only file that wires the agent together. Plugin
+ * registration order is largely free — `agent.memoryPlugin` is the
+ * CortexMemoryPlugin created inside CortexAgent's constructor and is available
+ * immediately, before any external plugin is registered.
  *
  * Usage:
  *   bun 2b.ts
@@ -43,6 +54,8 @@ const port =
 
 const debugTokens =
   args.includes("--debug-tokens") || process.env["DEBUG_TOKENS"] === "1";
+// When set, this callback is passed to providers / sub-agents so raw LLM tokens
+// stream to stdout as they arrive — useful for debugging slow or looping agents.
 const debugTokenCallback = debugTokens
   ? (token: string, isReasoning: boolean) => {
       // Gray for reasoning, plain for response tokens
@@ -51,6 +64,9 @@ const debugTokenCallback = debugTokens
   : undefined;
 
 // ── Inline tools ──────────────────────────────────────────────────────────────
+// These trivial utilities don't warrant their own plugin file. ToolDefinition
+// supports an `implementation` field so they can be registered as a bare plugin
+// object without subclassing. All other tools live in dedicated plugin files.
 
 const minimalTools: ToolDefinition[] = [
   {
@@ -86,6 +102,9 @@ const minimalToolsPlugin: AgentPlugin = {
 
 const llm = createProvider(model);
 
+// PermissionManager implementation is chosen by UI mode. WebPermissionManager
+// sends approval requests over SSE; InkPermissionManager renders an Ink prompt
+// inline in the terminal. Both implement the same PermissionManager interface.
 const permissionManager = useWeb
   ? new WebPermissionManager()
   : new InkPermissionManager();
@@ -112,6 +131,9 @@ const agent = new CortexAgent(llm, {
   systemPrompt,
 });
 
+// Resolve the absolute path to src/ relative to this entry file so the
+// codebase-explainer and DynamicAgentPlugin can scope file access correctly
+// regardless of the working directory from which `bun 2b.ts` is invoked.
 const sourceRoot = new URL("src/", import.meta.url).pathname;
 
 agent.registerPlugin(
@@ -177,6 +199,8 @@ if (useWeb) {
     model,
     systemPrompt,
     permissionManager: permissionManager as InkPermissionManager,
+    // onModelChange lets the UI swap the model at runtime without restarting
+    // the agent — the provider holds the current model string and updates it.
     onModelChange: (newModel) => llm.setModel(newModel),
   });
 }

--- a/src/agents/sub-agents/createCodebaseExplainerAgent.ts
+++ b/src/agents/sub-agents/createCodebaseExplainerAgent.ts
@@ -1,3 +1,15 @@
+/**
+ * Factory for the CodebaseExplainerAgent — the static sub-agent behind the
+ * `explore_codebase` tool in 2b.ts.
+ *
+ * Produces a read-only HeadlessAgent with SourceReaderPlugin. It can browse
+ * directories, read source files, and grep for symbols — but cannot modify
+ * anything.
+ *
+ * Critical: this is the only static sub-agent in the system. All other domain
+ * agents are constructed dynamically by DynamicAgentPlugin presets or at
+ * runtime via create_agent.
+ */
 import { HeadlessAgent } from "../../core/HeadlessAgent.ts";
 import type { LLMProvider } from "../../providers/llm/LLMProvider.ts";
 import { SourceReaderPlugin } from "../../plugins/SourceReaderPlugin.ts";
@@ -29,6 +41,14 @@ export interface CodebaseExplainerAgentOptions {
   onToken?: (token: string, isReasoning: boolean) => void;
 }
 
+/**
+ * Constructs a CodebaseExplainerAgent scoped to `options.sourceRoot`.
+ *
+ * @param llm     LLM provider — same instance as the orchestrator's.
+ * @param options.sourceRoot  Absolute path to the `src/` directory to expose.
+ *                            Defaults to cwd if omitted.
+ * @param options.onToken     Optional token callback for debug streaming.
+ */
 export function createCodebaseExplainerAgent(
   llm: LLMProvider,
   options: CodebaseExplainerAgentOptions = {},

--- a/src/core/BaseAgent.ts
+++ b/src/core/BaseAgent.ts
@@ -1,3 +1,29 @@
+/**
+ * BaseAgent — core event-driven orchestrator for the 2b agent framework.
+ *
+ * Manages two input queues and a heartbeat tick loop:
+ *   - directQueue  — messages that require an LLM response (addDirect)
+ *   - ambientQueue — passive perceptions; the LLM may reply [IGNORE] (addAmbient)
+ *
+ * Each tick drains both queues, assembles a system prompt from all plugins,
+ * collects conversation history, builds the tool list, calls the LLM, dispatches
+ * the response to plugins via onMessage, and emits "speak". Then schedules the
+ * next heartbeat.
+ *
+ * Plugin hooks called per tick (all wrapped in try-catch):
+ *   getSystemPromptFragment, getContext, getTools, executeTool,
+ *   onMessage, augmentResponse, onBeforeToolCall
+ *
+ * Tool dispatch: buildTools() wraps every plugin tool with permission gating
+ * (via PermissionManager) and veto checks (onBeforeToolCall). The result is
+ * cached in cachedTools and invalidated when new plugins are registered.
+ *
+ * Critical: this class is on every message path. Every user turn goes through
+ * tick() → act(). Errors in act() are caught, the queues are restored, and the
+ * "error" event is emitted — the tick loop continues.
+ *
+ * Use CortexAgent instead of BaseAgent directly for all new agents.
+ */
 import { EventEmitter } from "node:events";
 import type { LLMProvider } from "../providers/llm/LLMProvider.ts";
 import type { AgentPlugin, ToolDefinition } from "./Plugin.ts";
@@ -374,6 +400,22 @@ export class BaseAgent extends EventEmitter {
     return this.cachedTools;
   }
 
+  /**
+   * Core per-turn handler. Called by tick() when there is input to process.
+   *
+   * Sequence:
+   * 1. Emit state_change("thinking") and create an AbortController for this call.
+   * 2. Collect conversation history from plugins (collectMessages).
+   * 3. Assemble the system prompt from plugins (collectSystemPrompt).
+   * 4. Get the cached tool list (collectTools).
+   * 5. Call the LLM.
+   * 6. If ambient-only and the response is [IGNORE], return silently.
+   * 7. Run augmentResponse chain so plugins can transform the output.
+   * 8. Dispatch the final response to all plugins via onMessage.
+   * 9. Emit "speak" with the final response text.
+   *
+   * state_change("idle") is emitted in tick()'s finally block, not here.
+   */
   private async act(direct: string[], ambient: string[]) {
     this.emit("state_change", "thinking");
     this.currentAbortController = new AbortController();

--- a/src/core/CortexAgent.ts
+++ b/src/core/CortexAgent.ts
@@ -1,3 +1,23 @@
+/**
+ * CortexAgent — the preferred top-level agent class for all new agents.
+ *
+ * Wraps BaseAgent and pre-registers three core plugins at construction time:
+ *   - CortexMemoryPlugin  — semantic long-term memory (SQLite-backed)
+ *   - ThoughtPlugin       — extracts <think> blocks from LLM output and emits them
+ *   - MetacognitionPlugin — reads recent thoughts and surfaces behavioral insights
+ *
+ * The public API is a thin proxy to the inner BaseAgent — all methods forward
+ * through. This façade pattern keeps the cortex-specific setup isolated while
+ * preserving a clean, identical interface to callers.
+ *
+ * Critical: every message path goes through this class. Changes to constructor
+ * setup (plugin registration order, systemPrompt augmentation) affect all agents.
+ *
+ * Depends on:
+ *   - LLMProvider — the LLM connection (LMStudio by default)
+ *   - AgentConfig.cortexName / .name — determines SQLite filename for memory
+ *   - AgentConfig.memoryDbPath — override to ":memory:" in tests
+ */
 import { BaseAgent } from "./BaseAgent.ts";
 import type { LLMProvider } from "../providers/llm/LLMProvider.ts";
 import type { AgentPlugin } from "./Plugin.ts";
@@ -9,9 +29,22 @@ import { MetacognitionPlugin } from "../plugins/MetacognitionPlugin.ts";
 
 export class CortexAgent<TEvents extends AgentEventMap = AgentEventMap> {
   private inner: BaseAgent;
+  /**
+   * The CortexMemoryPlugin registered for this agent. Exposed so that
+   * DynamicAgentPlugin can pass it as `parentMemory` to sub-agents, allowing
+   * them to read the orchestrator's memories at task time.
+   */
   public readonly memoryPlugin: CortexMemoryPlugin;
 
+  /**
+   * @param llm             Primary LLM provider used for inference and memory operations.
+   * @param config          Agent configuration — see AgentConfig in types.ts.
+   * @param synthesisProvider Optional secondary LLM for ThoughtPlugin behavioral synthesis.
+   *                          Defaults to `llm` if omitted.
+   */
   constructor(llm: LLMProvider, config: AgentConfig, synthesisProvider?: LLMProvider) {
+    // Append cortex-specific directives after the caller's system prompt so they
+    // can't accidentally be overridden and always appear in every tick.
     const cortexSystemPrompt = [
       config.systemPrompt,
       "You have internal thoughts stored in thought memory. Review recent thoughts before responding.",

--- a/src/core/HeadlessAgent.ts
+++ b/src/core/HeadlessAgent.ts
@@ -1,3 +1,22 @@
+/**
+ * HeadlessAgent — stateless single-call agent, the building block for sub-agents.
+ *
+ * Each `ask()` call is fully independent: it collects system prompt fragments,
+ * builds the tool list, calls the LLM, and returns. No conversation history,
+ * no tick loop, no input sources.
+ *
+ * Plugin hooks NOT called: onInit, onMessage, getMessages, augmentResponse.
+ * Plugin hooks that ARE called per ask(): getSystemPromptFragment, getContext,
+ * getTools, executeTool.
+ *
+ * Security: the consecutive-tool circuit breaker (default: 5 calls per tool)
+ * prevents infinite loops when a model gets stuck retrying the same failing call.
+ * It resets when the model switches to a different tool.
+ *
+ * Critical: used as the backing agent for DynamicAgentPlugin's "headless" type
+ * and for static sub-agents registered via SubAgentPlugin. Changes here affect
+ * all spawned sub-agents.
+ */
 import type { LLMProvider } from "../providers/llm/LLMProvider.ts";
 import type { AgentPlugin, ToolDefinition } from "./Plugin.ts";
 import type { Message } from "./types.ts";

--- a/src/core/Plugin.ts
+++ b/src/core/Plugin.ts
@@ -1,7 +1,38 @@
+/**
+ * Core plugin interface for the 2b agent framework.
+ *
+ * Every capability the agent has beyond raw LLM inference is delivered through a
+ * plugin. Plugins can contribute any combination of:
+ *   - Tools the LLM can invoke (`getTools` / `executeTool`)
+ *   - Persistent system-prompt context (`getSystemPromptFragment`)
+ *   - Per-turn injected context (`getContext`)
+ *   - Conversation history (`getMessages`)
+ *   - Side effects on each message (`onMessage`)
+ *   - Pre-tool guards (`onBeforeToolCall`)
+ *   - Post-response transformations (`augmentResponse`)
+ *
+ * All plugin hooks are called inside try-catch by BaseAgent — a throwing plugin
+ * never crashes the agent.
+ *
+ * Critical: this file is the contract every plugin must satisfy. Changing these
+ * interfaces is a breaking change for all plugins.
+ */
 import type { BaseAgent } from "./BaseAgent.ts";
 import type { Message } from "./types.ts";
 import type { PermissionLevel } from "./PermissionManager.ts";
 
+/**
+ * Describes a single callable tool that the LLM can invoke.
+ *
+ * If `implementation` is provided, BaseAgent calls it directly (used for inline
+ * tools in 2b.ts). If omitted, the call is routed to `executeTool` on the plugin
+ * that returned this definition from `getTools()`.
+ *
+ * `permission` controls whether the user must approve each call:
+ *   - "none"      — always auto-approved (default)
+ *   - "per_call"  — user approves each invocation
+ *   - "session"   — user approves once; subsequent calls in the session are auto-approved
+ */
 export interface ToolDefinition {
   name: string;
   description: string;

--- a/src/plugins/DynamicAgentPlugin.ts
+++ b/src/plugins/DynamicAgentPlugin.ts
@@ -1,3 +1,25 @@
+/**
+ * DynamicAgentPlugin — runtime sub-agent spawning and dispatch.
+ *
+ * Exposes four LLM-callable tools: list_capabilities, create_agent, call_agent,
+ * list_agents. When the LLM calls create_agent, the plugin constructs either a
+ * stateless HeadlessAgent or a persistent CortexSubAgent, wires up event
+ * forwarding to the parent, and stores it in the registry.
+ *
+ * All tool events emitted by sub-agents bubble up through the parent's
+ * "subagent_tool_call" event so the UI can display them without subscribing
+ * to each sub-agent individually.
+ *
+ * Critical: this plugin is on the path of every create_agent / call_agent
+ * invocation. Spawning a cortex agent creates a CortexSubAgent instance with
+ * in-memory SQLite — those stay alive for the session.
+ *
+ * Depends on:
+ *   - CAPABILITY_REGISTRY — maps capability names to plugin builder functions
+ *   - LLMProvider and PermissionManager passed at construction
+ *   - parentMemory (optional) — CortexMemoryPlugin from the orchestrator;
+ *     injected into cortex sub-agents via ParentMemoryBridgePlugin
+ */
 import type { AgentPlugin, ToolDefinition } from "../core/Plugin.ts";
 import type { BaseAgent } from "../core/BaseAgent.ts";
 import type { LLMProvider } from "../providers/llm/LLMProvider.ts";
@@ -187,6 +209,7 @@ export class DynamicAgentPlugin implements AgentPlugin {
   name = "DynamicAgent";
   private parentAgent?: BaseAgent;
   private readonly registry = new Map<string, DynamicAgentEntry>();
+  /** Tracks in-flight ask() calls so interruptAll() can cancel them. */
   private readonly activeAsks = new Set<AskableAgent>();
   private readonly llm: LLMProvider;
   private readonly permissionManager?: PermissionManager;
@@ -392,6 +415,8 @@ export class DynamicAgentPlugin implements AgentPlugin {
     if (this.parentAgent) {
       const parent = this.parentAgent;
 
+      // Forward every sub-agent tool call to the parent so UI subscribers
+      // (e.g. TerminalUI) can display them without wiring each sub-agent.
       agent.setToolCallHandler((toolName, toolArgs) => {
         parent.emit(
           "subagent_tool_call",
@@ -402,6 +427,8 @@ export class DynamicAgentPlugin implements AgentPlugin {
         );
       });
 
+      // Cortex sub-agents also emit state and error events so the UI can show
+      // per-agent thinking/idle state transitions.
       if (agentType === "cortex") {
         const cortexAgent = agent as CortexSubAgent;
         cortexAgent.setStateChangeHandler((state) => {

--- a/src/plugins/FileSystemPlugin.ts
+++ b/src/plugins/FileSystemPlugin.ts
@@ -1,3 +1,32 @@
+/**
+ * FileSystemPlugin — full local filesystem access for the agent.
+ *
+ * Tools: read_file, write_file, append_file, list_directory, move_file,
+ * copy_file, delete_file, delete_directory, make_directory, stat_file,
+ * find_files, search_in_files, patch_file, patch_file_range.
+ *
+ * All paths are sandboxed to `allowedRoots` (default: process.cwd()).
+ * `resolveSafe()` is the enforcement point — every private method calls it
+ * before touching the filesystem.
+ *
+ * Mutating tools carry `permission: "per_call"` so the user is prompted
+ * before each destructive operation.
+ *
+ * patch_file uses a two-pass approach: validate all edits against the current
+ * file content first (fail fast, no partial writes), then apply in reverse
+ * offset order so earlier edits don't shift the positions of later ones.
+ * Falls back to a whitespace-normalized match when exact match fails.
+ *
+ * patch_file_range streams the file through a temp file to support large
+ * files (>10 MB) without loading them fully into memory.
+ *
+ * search_in_files uses ripgrep if available; falls back to a built-in
+ * Bun.Glob + regex scanner otherwise.
+ *
+ * Critical: this plugin gives the agent write access to the host filesystem.
+ * The path sandbox and per_call permission on write tools are the primary
+ * safeguards.
+ */
 import type { AgentPlugin, ToolDefinition } from "../core/Plugin.ts";
 import { logger } from "../logger.ts";
 import { join, resolve, dirname, sep } from "node:path";
@@ -42,6 +71,13 @@ type MatchResult =
   | { found: true; start: number; end: number; fuzzy: boolean }
   | { found: false; error: string };
 
+/**
+ * Finds the unique occurrence of `search` in `content`.
+ * Returns the byte-offset range [start, end) if found exactly once.
+ * If not found exactly, retries with leading whitespace stripped from each
+ * line — useful when the LLM's indentation doesn't precisely match the file.
+ * Returns an error if the match is ambiguous (occurs more than once).
+ */
 function findMatch(content: string, search: string): MatchResult {
   // Exact match
   const first = content.indexOf(search);
@@ -115,6 +151,11 @@ export class FileSystemPlugin implements AgentPlugin {
       options?.allowedRoots?.map((r) => resolve(r)) ?? [process.cwd()];
   }
 
+  /**
+   * Resolves `path` to an absolute path and verifies it falls within one of the
+   * allowed roots. Throws for any path that escapes the sandbox (e.g. `../../etc`).
+   * This is the single enforcement point — all private file methods must call it.
+   */
   private resolveSafe(path: string): string {
     const resolved = resolve(this.allowedRoots[0]!, path);
     for (const root of this.allowedRoots) {

--- a/src/plugins/MemoryPlugin.ts
+++ b/src/plugins/MemoryPlugin.ts
@@ -1,9 +1,31 @@
+/**
+ * MemoryPlugin — short-term conversation history with automatic summarization.
+ *
+ * Stores the rolling message history that BaseAgent replays on each LLM call.
+ * When the history exceeds MAX_MESSAGES (default 15), it fires a background LLM
+ * pass to condense old messages into a structured summary, then optionally runs
+ * a second pass to extract reusable procedures. The trimmed history plus summary
+ * are what the agent "remembers" going forward.
+ *
+ * This is distinct from CortexMemoryPlugin (long-term semantic memory). This
+ * plugin manages the LLM's context window; CortexMemoryPlugin manages
+ * persistent cross-session knowledge.
+ *
+ * Critical: every user and assistant message passes through `onMessage()`.
+ * Breaking this interrupts the agent's ability to follow multi-turn conversations.
+ *
+ * Depends on:
+ *   - LLMProvider — used for the background summarization and procedure extraction calls
+ *   - BaseAgent.getLastSystemPrompt() — included in summarization so the LLM has context
+ *   - BaseAgent.requestMemoryWrite() — to persist summaries and procedures to long-term memory
+ */
 import type { Message } from "../core/types.ts";
 import type { AgentPlugin } from "../core/Plugin.ts";
 import type { LLMProvider } from "../providers/llm/LLMProvider.ts";
 import type { BaseAgent } from "../core/BaseAgent.ts";
 import { logger } from "../logger.ts";
 
+/** @see module-level JSDoc above for full description. */
 export class MemoryPlugin implements AgentPlugin {
   name = "MemoryPlugin";
 

--- a/src/plugins/ScratchPlugin.ts
+++ b/src/plugins/ScratchPlugin.ts
@@ -1,3 +1,26 @@
+/**
+ * ScratchPlugin — session scratch pad and active-goal system.
+ *
+ * Two responsibilities:
+ *
+ * 1. **Scratch pad**: temp files stored in OS tmpdir under a per-session UUID
+ *    directory. The agent can write named text snippets before context
+ *    summarization erases them, then retrieve them verbatim later. The file
+ *    index is injected into `getContext()` every turn so the list itself
+ *    survives summarization even if the messages describing what was written
+ *    do not.
+ *
+ * 2. **Active goal**: a plain string pinned into `getSystemPromptFragment()`
+ *    for the lifetime of the session. The LLM calls `set_active_goal` when
+ *    it receives a multi-turn task; the goal text appears in every subsequent
+ *    system prompt and survives message summarization. Cleared via
+ *    `clear_active_goal` when the task finishes.
+ *
+ * Neither system is persisted to disk between sessions. All state is in-memory
+ * (or in OS tmpdir, which the OS cleans on reboot).
+ *
+ * Depends on: OS tmpdir (node:os), Bun.file / Bun.write for file I/O.
+ */
 import type { AgentPlugin, ToolDefinition } from "../core/Plugin.ts";
 import { logger } from "../logger.ts";
 import { tmpdir } from "node:os";
@@ -36,6 +59,11 @@ export class ScratchPlugin implements AgentPlugin {
 
   readonly sessionDir: string;
   private initialized = false;
+  /**
+   * In-memory active goal string. Injected into every system prompt via
+   * getSystemPromptFragment() so it survives MemoryPlugin's summarization cycle.
+   * Null means no active goal.
+   */
   private activeGoal: string | null = null;
 
   constructor(sessionId?: string) {

--- a/src/plugins/ShellPlugin.ts
+++ b/src/plugins/ShellPlugin.ts
@@ -1,3 +1,19 @@
+/**
+ * ShellPlugin — restricted read-only shell access.
+ *
+ * Exposes a single `run_shell` tool. Commands are validated against an
+ * allowlist before execution:
+ *   - Only commands in ALLOWED_COMMANDS may be run.
+ *   - `git` is further restricted to read-only subcommands (ALLOWED_GIT_SUBCOMMANDS).
+ *   - `find` blocks action flags (-exec, -delete, etc.) via BLOCKED_ARGS.
+ *   - Shell operators (|, &&, >, ;) are blocked by refusing to pass the command
+ *     to a shell — it is split on whitespace and spawned directly via Bun.spawn.
+ *   - ANSI escape sequences are stripped from output before returning.
+ *   - stdout is capped at 4 KB; stderr at 1 KB to keep tool results small.
+ *
+ * Critical: the lack of a shell interpreter is the primary sandboxing mechanism.
+ * If you ever switch to `sh -c` or similar, all shell injection guards break.
+ */
 import type { AgentPlugin, ToolDefinition } from "../core/Plugin.ts";
 import { logger } from "../logger.ts";
 import { resolve } from "node:path";

--- a/src/plugins/SubAgentPlugin.ts
+++ b/src/plugins/SubAgentPlugin.ts
@@ -1,3 +1,18 @@
+/**
+ * SubAgentPlugin — wraps a single HeadlessAgent as a named tool on the
+ * orchestrator.
+ *
+ * Used for static sub-agents that are always available (e.g. explore_codebase).
+ * For runtime-spawned agents use DynamicAgentPlugin instead.
+ *
+ * Exposes one tool whose name and description are set at construction time.
+ * Sub-agent tool calls are forwarded to the parent agent's "subagent_tool_call"
+ * event so the UI can display them. Token stream is forwarded via "subagent_token".
+ *
+ * Optionally enforces:
+ *   - inactivityTimeoutMs: reset on each tool call from the sub-agent
+ *   - absoluteTimeoutMs: hard cap on the entire ask() call
+ */
 import type { AgentPlugin, ToolDefinition } from "../core/Plugin.ts";
 import type { BaseAgent } from "../core/BaseAgent.ts";
 import type { HeadlessAgent } from "../core/HeadlessAgent.ts";

--- a/src/providers/llm/ModelCapabilityProvider.ts
+++ b/src/providers/llm/ModelCapabilityProvider.ts
@@ -1,3 +1,16 @@
+/**
+ * ModelCapabilityProvider — transparent decorator over any LLMProvider.
+ *
+ * Intercepts every `chat()` call to prepend a model-specific system prompt
+ * prefix (e.g. thinking-mode headers required by some models) before forwarding
+ * to the inner provider.
+ *
+ * Also surfaces `setModel` / `getModel` so the UI can hot-swap the active model
+ * without reconstructing the agent.
+ *
+ * Critical: all inference goes through this class. Adding a new capability
+ * (e.g. per-model max-tokens injection) belongs here.
+ */
 import type { LLMProvider, ChatResponse } from "./LLMProvider.ts";
 import type { ToolDefinition } from "../../core/Plugin.ts";
 import type { Message } from "../../core/types.ts";
@@ -29,6 +42,8 @@ export class ModelCapabilityProvider implements LLMProvider {
     onToken?: (token: string, isReasoning: boolean) => void,
   ): Promise<ChatResponse> {
     const { systemPromptPrefix } = getModelCapabilities(this.model);
+    // Build the effective system prompt: prefix takes precedence over a missing
+    // base prompt, but is always prepended when both are present.
     const effectivePrompt =
       systemPromptPrefix && systemPrompt !== undefined
         ? `${systemPromptPrefix}${systemPrompt}`

--- a/src/providers/llm/createProvider.ts
+++ b/src/providers/llm/createProvider.ts
@@ -5,6 +5,10 @@ import { ModelCapabilityProvider } from "./ModelCapabilityProvider.ts";
 /**
  * Constructs an LLMProvider from environment variables.
  *
+ * Always returns a ModelCapabilityProvider wrapping the concrete backend so
+ * model-specific system prompt prefixes are applied transparently, and so
+ * `setModel()` / `getModel()` are always available for hot-swapping.
+ *
  * Set PROVIDER=ollama to use Ollama, otherwise LMStudio is used.
  *
  * Shared env vars:

--- a/src/ui/ChatSession.ts
+++ b/src/ui/ChatSession.ts
@@ -1,3 +1,21 @@
+/**
+ * ChatSession — framework-agnostic bridge between an agent and a UI.
+ *
+ * Subscribes to the agent's event stream and normalises it into a flat list of
+ * ChatMessages, a per-turn active-tool list, and a dynamic-agent registry.
+ * UIs (TerminalChat, web server) subscribe to ChatSession events instead of
+ * wiring the agent directly — this keeps UI code decoupled from agent internals.
+ *
+ * Events emitted:
+ *   "message"               — new ChatMessage appended
+ *   "message_updated"       — existing message patched (streaming, tool calls, etc.)
+ *   "state_change"          — "idle" | "thinking"
+ *   "active_tools_changed"  — current list of in-flight tools
+ *   "dynamic_agents_changed"— current list of spawned sub-agents and their states
+ *
+ * Critical: both terminal and web UIs depend on this. Changes to event names or
+ * ChatMessage shape are breaking changes across both UIs.
+ */
 import { EventEmitter } from "node:events";
 import type { AgentEventMap } from "../core/types.ts";
 import type {

--- a/src/ui/terminal/run.tsx
+++ b/src/ui/terminal/run.tsx
@@ -1,3 +1,15 @@
+/**
+ * Terminal UI entry point.
+ *
+ * Starts the agent, wraps it in a ChatSession, then mounts the Ink-based
+ * TerminalChat React component. Ink takes over stdout for the session lifetime.
+ *
+ * `onModelChange` is wired through so the user can switch models mid-session
+ * via a UI command; it calls `llm.setModel()` back in 2b.ts.
+ *
+ * Critical: `agent.start()` must complete before rendering so all plugins are
+ * initialized and the heartbeat loop is running before the first input arrives.
+ */
 import { render } from "ink";
 import type { CortexAgent } from "../../core/CortexAgent.ts";
 import { InkPermissionManager } from "./InkPermissionManager.ts";

--- a/src/ui/web/server.ts
+++ b/src/ui/web/server.ts
@@ -1,3 +1,36 @@
+/**
+ * Web UI entry point — Bun HTTP + WebSocket server.
+ *
+ * Serves the bundled SPA (index.html) and upgrades any WebSocket connection to
+ * a real-time agent session. Only one WebSocket client is tracked at a time
+ * (`activeWs`); a new connection replaces the previous one's event listeners.
+ *
+ * WebSocket message protocol (client → server):
+ *   { type: "send",              text }
+ *   { type: "interrupt",         scope: "main"|"subagents"|"all" }
+ *   { type: "clear" }
+ *   { type: "permission_response", response: "yes"|"always"|"no" }
+ *   { type: "model_change",      model }
+ *   { type: "system_prompt_request" }
+ *
+ * WebSocket message protocol (server → client):
+ *   { type: "snapshot",          ...session.getSnapshot() }
+ *   { type: "message",           message }
+ *   { type: "message_updated",   message }
+ *   { type: "state_change",      state }
+ *   { type: "active_tools_changed", tools }
+ *   { type: "dynamic_agents_changed", agents }
+ *   { type: "permission_request", ...request }   — via WebPermissionManager transport
+ *   { type: "model_changed",     model }
+ *   { type: "system_prompt",     systemPrompt, model }
+ *
+ * The `lastPermissionToolName` module-level variable is a workaround: the
+ * WebPermissionManager resolves approvals asynchronously, so the "always"
+ * response handler needs to know which tool to cache — it reads this.
+ *
+ * Critical: `agent.start()` must be called before `Bun.serve()` so plugins
+ * are ready before the first WebSocket message arrives.
+ */
 import type { ServerWebSocket } from "bun";
 import type { CortexAgent } from "../../core/CortexAgent.ts";
 import { ChatSession } from "../ChatSession.ts";


### PR DESCRIPTION
Crawled the full agent from 2b.ts through every critical import and added file-level JSDoc, class/function docs, and inline comments covering: what each file achieves, what it depends on, how critical it is, and non-obvious design choices (patch_file two-pass algorithm, tool cache invalidation, cortex system prompt augmentation, shell no-interpreter sandbox, etc.).

17 files documented: 2b.ts, BaseAgent, CortexAgent, HeadlessAgent, Plugin, createProvider, ModelCapabilityProvider, DynamicAgentPlugin, SubAgentPlugin, createCodebaseExplainerAgent, MemoryPlugin, ScratchPlugin, FileSystemPlugin, ShellPlugin, ChatSession, terminal/run.tsx, web/server.ts.