### PR TITLE
feat: extract BehaviorPlugin and add web management dashboard

### DIFF
--- a/2b.ts
+++ b/2b.ts
@@ -33,6 +33,7 @@ import { WebPermissionManager } from "./src/ui/web/WebPermissionManager.ts";
 import type { AgentPlugin, ToolDefinition } from "./src/core/Plugin.ts";
 import { createCodebaseExplainerAgent } from "./src/agents/sub-agents/createCodebaseExplainerAgent.ts";
 import { ScratchPlugin } from "./src/plugins/ScratchPlugin.ts";
+import { BehaviorPlugin } from "./src/plugins/BehaviorPlugin.ts";
 import { DynamicAgentPlugin } from "./src/plugins/DynamicAgentPlugin.ts";
 import { FileSystemPlugin } from "./src/plugins/FileSystemPlugin.ts";
 import { ShellPlugin } from "./src/plugins/ShellPlugin.ts";
@@ -174,6 +175,8 @@ agent.registerPlugin(
   }),
 );
 
+const behaviorPlugin = new BehaviorPlugin(agent.memoryPlugin, llm);
+agent.registerPlugin(behaviorPlugin);
 agent.registerPlugin(new FileSystemPlugin());
 agent.registerPlugin(new ShellPlugin());
 agent.registerPlugin(minimalToolsPlugin);
@@ -192,6 +195,8 @@ if (useWeb) {
     permissionManager: permissionManager as WebPermissionManager,
     onModelChange: (newModel) => llm.setModel(newModel),
     port,
+    memoryPlugin: agent.memoryPlugin,
+    behaviorPlugin,
   });
 } else {
   await startTerminalUI({

--- a/src/core/types.ts
+++ b/src/core/types.ts
@@ -32,6 +32,10 @@ export interface AgentEventMap {
   agent_error: [agentName: string, err: Error];
   /** Emitted by plugins that produce content for long-term persistence. */
   "memory:write_request": [request: MemoryWriteRequest];
+  /** Emitted by BehaviorPlugin when a newly saved behavior semantically conflicts with an existing one. */
+  "behavior:conflict_detected": [newId: string, newText: string, conflictId: string, conflictText: string, score: number];
+  /** Emitted by BehaviorPlugin after each turn's system prompt fragment is assembled. */
+  "behaviors_loaded": [core: Array<{ id: string; text: string; weight: number }>, contextual: Array<{ id: string; text: string; score: number; weight: number }>];
 }
 
 export type Message = {

--- a/src/plugins/BehaviorPlugin.ts
+++ b/src/plugins/BehaviorPlugin.ts
@@ -55,8 +55,8 @@ export class BehaviorPlugin implements AgentPlugin {
   /** Profile behaviors loaded via activate_profile — injected until session ends. */
   private profileBehaviors: Array<{ id: string; text: string; weight: number }> = [];
 
-  /** Pending conflict queue — exposed to web UI via REST. */
-  public pendingConflicts: Map<string, ConflictRecord> = new Map();
+  /** Pending conflict queue — accessed externally only via getConflicts() and dismissConflict(). */
+  private pendingConflicts: Map<string, ConflictRecord> = new Map();
 
   constructor(memoryPlugin: CortexMemoryPlugin, llm: LLMProvider) {
     this.memoryPlugin = memoryPlugin;

--- a/src/plugins/BehaviorPlugin.ts
+++ b/src/plugins/BehaviorPlugin.ts
@@ -1,0 +1,444 @@
+/**
+ * BehaviorPlugin — owns behavior injection, self-shaping tools, and conflict detection.
+ *
+ * Extracted from CortexMemoryPlugin so that self-shaping is an opt-in capability
+ * rather than baked into the memory system. CortexMemoryPlugin remains the backing
+ * store for behavior memories; BehaviorPlugin reads and writes through its public API.
+ *
+ * Behavior injection uses a weight spectrum (0.0–1.0) instead of the old binary
+ * core/contextual split:
+ *   - weight >= 0.9 OR tagged "core" → always injected, bypasses embedding search
+ *   - weight < 0.9 → semantic retrieval; effective threshold = (1 - weight) * 0.5
+ *     clamped to [0.15, 0.5] so high-weight rules fire broadly, low-weight rules
+ *     only when contextually close.
+ *
+ * Conflict detection runs on every save_behavior call. If the new behavior has
+ * similarity 0.5–0.85 with an existing one (similar enough to conflict, not similar
+ * enough to dedup), the tool result includes a warning and a
+ * `behavior:conflict_detected` event is emitted for the web UI.
+ *
+ * Tools provided:
+ *   save_behavior         — save a new behavioral rule with optional weight
+ *   synthesize_behaviors  — resolve a conflict via structured LLM synthesis
+ *   activate_profile      — force-load all behaviors tagged with a profile name
+ *   force_behavior        — pin a specific behavior ID for the session
+ *   suppress_behavior     — exclude a specific behavior ID for the session
+ */
+import type { AgentPlugin, ToolDefinition } from "../core/Plugin.ts";
+import type { BaseAgent } from "../core/BaseAgent.ts";
+import type { LLMProvider } from "../providers/llm/LLMProvider.ts";
+import type { CortexMemoryPlugin } from "./CortexMemoryPlugin.ts";
+import { logger } from "../logger.ts";
+
+const MAX_CONTENT_LENGTH = 10_000;
+
+export interface ConflictRecord {
+  newId: string;
+  newText: string;
+  conflictId: string;
+  conflictText: string;
+  score: number;
+  timestamp: number;
+}
+
+export class BehaviorPlugin implements AgentPlugin {
+  name = "Behavior";
+
+  private memoryPlugin: CortexMemoryPlugin;
+  private llm: LLMProvider;
+  private agent: BaseAgent | null = null;
+
+  /** Session-level forced behavior IDs — always injected regardless of weight/score. */
+  private forcedBehaviorIds: Set<string> = new Set();
+  /** Session-level suppressed behavior IDs — never injected. */
+  private suppressedBehaviorIds: Set<string> = new Set();
+  /** Profile behaviors loaded via activate_profile — injected until session ends. */
+  private profileBehaviors: Array<{ id: string; text: string; weight: number }> = [];
+
+  /** Pending conflict queue — exposed to web UI via REST. */
+  public pendingConflicts: Map<string, ConflictRecord> = new Map();
+
+  constructor(memoryPlugin: CortexMemoryPlugin, llm: LLMProvider) {
+    this.memoryPlugin = memoryPlugin;
+    this.llm = llm;
+  }
+
+  onInit(agent: BaseAgent): void {
+    this.agent = agent;
+  }
+
+  // ── System prompt injection ───────────────────────────────────────────────
+
+  async getSystemPromptFragment(context?: string): Promise<string> {
+    const parts: string[] = [
+      "## Behavior System",
+      "You have a self-shaping behavior system. Behaviors are persistent rules that actively shape how you respond.",
+      "Use `save_behavior` to record a new behavioral rule.",
+      "  - `weight` (0.0–1.0): how strongly this rule applies. 1.0 = always active (personality-level). 0.5 = general preference. 0.1 = situational only. Default: 0.5.",
+      "  - `core: true` is shorthand for weight 1.0 — always injected into every turn.",
+      "  - Tagging behaviors with profile names (e.g. `tags: [\"technical\"]`) lets you `activate_profile(\"technical\")` to load all matching behaviors for the session.",
+      "Use `synthesize_behaviors` to resolve a flagged conflict between two behaviors.",
+      "Use `activate_profile` to force-load all behaviors tagged with a given profile name.",
+      "Use `force_behavior` to pin a specific behavior ID as active for this session.",
+      "Use `suppress_behavior` to exclude a specific behavior ID from this session.",
+      "When a conflict is detected after saving a behavior, call `synthesize_behaviors` to resolve it — or dismiss by ignoring the warning.",
+    ];
+
+    try {
+      const coreBehaviors: Array<{ id: string; text: string; weight: number }> = [];
+      const contextualBehaviors: Array<{ id: string; text: string; score: number; weight: number }> = [];
+
+      // ── Sticky behaviors: weight >= 0.9 or tagged "core" ─────────────────
+      const allBehaviors = this.memoryPlugin.queryMemoriesRaw({ types: ["behavior"], limit: 200 });
+      const stickySet = new Set<string>();
+
+      for (const b of allBehaviors) {
+        if (this.suppressedBehaviorIds.has(b.id)) continue;
+        const isSticky = (b.weight ?? 1.0) >= 0.9 || b.tags.includes("core");
+        if (isSticky) {
+          coreBehaviors.push({ id: b.id, text: b.text, weight: b.weight ?? 1.0 });
+          stickySet.add(b.id);
+        }
+      }
+
+      // ── Forced session behaviors ──────────────────────────────────────────
+      for (const id of this.forcedBehaviorIds) {
+        if (stickySet.has(id) || this.suppressedBehaviorIds.has(id)) continue;
+        const b = await this.memoryPlugin.getMemoryById(id);
+        if (b && b.status === "active") {
+          coreBehaviors.push({ id: b.id, text: b.text, weight: b.weight });
+          stickySet.add(id);
+        }
+      }
+
+      // ── Profile behaviors ─────────────────────────────────────────────────
+      for (const pb of this.profileBehaviors) {
+        if (stickySet.has(pb.id) || this.suppressedBehaviorIds.has(pb.id)) continue;
+        coreBehaviors.push(pb);
+        stickySet.add(pb.id);
+      }
+
+      // ── Contextual behaviors: semantic search, weight-adjusted threshold ──
+      if (context?.trim()) {
+        const embedding = await this.memoryPlugin.getOrComputeEmbedding(context);
+        // Search at minimum possible threshold — filter each result by its own weight-adjusted threshold
+        const candidates = this.memoryPlugin.searchBehaviorsWithEmbedding(embedding, 30, 0.15);
+        for (const c of candidates) {
+          if (stickySet.has(c.id) || this.suppressedBehaviorIds.has(c.id)) continue;
+          const weight = c.weight ?? 1.0;
+          const effectiveThreshold = Math.max(0.15, Math.min(0.5, (1.0 - weight) * 0.5));
+          if (c.score >= effectiveThreshold) {
+            contextualBehaviors.push({ id: c.id, text: c.text, score: c.score, weight });
+          }
+        }
+        // Sort by weight desc, then score desc; cap at 15
+        contextualBehaviors.sort((a, b) => (b.weight - a.weight) || (b.score - a.score));
+        contextualBehaviors.splice(15);
+      } else {
+        // No context yet — fall back to most recent non-sticky behaviors
+        const recent = this.memoryPlugin.queryMemoriesRaw({ types: ["behavior"], limit: 30 });
+        for (const r of recent) {
+          if (stickySet.has(r.id) || this.suppressedBehaviorIds.has(r.id)) continue;
+          if ((r.weight ?? 1.0) < 0.9) {
+            contextualBehaviors.push({ id: r.id, text: r.text, score: 1.0, weight: r.weight ?? 1.0 });
+            if (contextualBehaviors.length >= 15) break;
+          }
+        }
+      }
+
+      logger.debug(
+        this.name,
+        `getSystemPromptFragment: ${coreBehaviors.length} sticky + ${contextualBehaviors.length} contextual behaviors`,
+      );
+
+      if (coreBehaviors.length > 0) {
+        parts.push("\n## Always Active Behaviors");
+        for (const b of coreBehaviors) {
+          parts.push(`- ${b.text.trim()}`);
+        }
+      }
+      if (contextualBehaviors.length > 0) {
+        parts.push("\n## Contextually Active Behaviors");
+        for (const b of contextualBehaviors) {
+          parts.push(`- ${b.text.trim()}`);
+        }
+      }
+
+      // Emit behaviors_loaded for web UI
+      if (this.agent) {
+        this.agent.emit("behaviors_loaded", coreBehaviors, contextualBehaviors);
+      }
+    } catch (e) {
+      logger.error(this.name, "Failed to load behavior memories for system prompt:", e);
+    }
+
+    return parts.join("\n");
+  }
+
+  // ── Tools ─────────────────────────────────────────────────────────────────
+
+  getTools(): ToolDefinition[] {
+    return [
+      {
+        name: "save_behavior",
+        description:
+          "Save a persistent behavioral rule that shapes how you respond. `weight` (0.0–1.0) controls when it activates: 1.0 = always active (personality-level), 0.5 = general preference (default), 0.1 = fires only when contextually close. `core: true` is shorthand for weight 1.0. Tag with profile names (e.g. `tags: [\"technical\"]`) to group related behaviors. After saving, a conflict check runs automatically — if a conflict is detected you will be prompted to call `synthesize_behaviors`.",
+        parameters: {
+          type: "object",
+          properties: {
+            rule: { type: "string", description: "The behavioral rule to persist" },
+            weight: {
+              type: "number",
+              description: "Injection priority from 0.0 (situational) to 1.0 (always active). Default: 0.5.",
+            },
+            core: {
+              type: "boolean",
+              description: "Shorthand for weight 1.0 — always injected. Takes precedence over `weight` if both provided.",
+            },
+            tags: {
+              type: "array",
+              items: { type: "string" },
+              description: "Optional tags, e.g. profile names like 'technical', 'creative'.",
+            },
+          },
+          required: ["rule"],
+        },
+      },
+      {
+        name: "synthesize_behaviors",
+        description:
+          "Resolve a conflict between two behaviors by synthesizing them into a single unified rule. Both originals are superseded. Call this after a conflict is flagged by save_behavior.",
+        parameters: {
+          type: "object",
+          properties: {
+            id_a: { type: "string", description: "ID of the first behavior" },
+            id_b: { type: "string", description: "ID of the second behavior" },
+          },
+          required: ["id_a", "id_b"],
+        },
+      },
+      {
+        name: "activate_profile",
+        description:
+          "Force-load all behaviors tagged with a given profile name for the rest of this session, regardless of their weight or semantic relevance. Use to switch into a mode like 'technical' or 'creative'.",
+        parameters: {
+          type: "object",
+          properties: {
+            profile: { type: "string", description: "The tag/profile name to activate" },
+          },
+          required: ["profile"],
+        },
+      },
+      {
+        name: "force_behavior",
+        description: "Pin a specific behavior by ID as always-active for this session.",
+        parameters: {
+          type: "object",
+          properties: {
+            id: { type: "string", description: "Behavior memory ID to force-activate" },
+          },
+          required: ["id"],
+        },
+      },
+      {
+        name: "suppress_behavior",
+        description: "Exclude a specific behavior by ID from firing for the rest of this session.",
+        parameters: {
+          type: "object",
+          properties: {
+            id: { type: "string", description: "Behavior memory ID to suppress" },
+          },
+          required: ["id"],
+        },
+      },
+    ];
+  }
+
+  async executeTool(name: string, args: any): Promise<string | undefined> {
+    try {
+      if (name === "save_behavior") return await this.handleSaveBehavior(args);
+      if (name === "synthesize_behaviors") return await this.handleSynthesizeBehaviors(args);
+      if (name === "activate_profile") return this.handleActivateProfile(args);
+      if (name === "force_behavior") return this.handleForceBehavior(args);
+      if (name === "suppress_behavior") return this.handleSuppressBehavior(args);
+    } catch (e) {
+      logger.error(this.name, `Tool error (${name}):`, e);
+      return `Tool error: ${e instanceof Error ? e.message : String(e)}`;
+    }
+  }
+
+  // ── Tool handlers ─────────────────────────────────────────────────────────
+
+  private async handleSaveBehavior(args: any): Promise<string> {
+    const rule = String(args.rule ?? "").trim();
+    if (!rule) return "Behavior rule cannot be empty.";
+    if (rule.length > MAX_CONTENT_LENGTH) {
+      return `Behavior rule too long (${rule.length} chars). Maximum is ${MAX_CONTENT_LENGTH} characters.`;
+    }
+
+    const isCore = args.core === true;
+    const rawWeight = typeof args.weight === "number" ? args.weight : 0.5;
+    const weight = isCore ? 1.0 : Math.max(0, Math.min(1, rawWeight));
+    const tags: string[] = Array.isArray(args.tags) ? args.tags.map(String) : [];
+    if (isCore && !tags.includes("core")) tags.push("core");
+
+    logger.info(this.name, `save_behavior [weight=${weight.toFixed(2)}]: "${rule.slice(0, 100)}"`);
+
+    const id = await this.memoryPlugin.writeMemory(rule, "behavior", tags, "BehaviorPlugin", weight);
+    if (id === null) {
+      return "Behavior skipped — a near-identical rule already exists.";
+    }
+
+    // ── Conflict detection: similarity 0.5–0.85 ───────────────────────────
+    const conflictWarnings: string[] = [];
+    try {
+      const embedding = await this.memoryPlugin.getOrComputeEmbedding(rule);
+      const candidates = this.memoryPlugin.searchBehaviorsWithEmbedding(embedding, 5, 0.5);
+      for (const c of candidates) {
+        if (c.id === id) continue; // skip the just-saved behavior
+        if (c.score >= 0.85) continue; // handled by dedup (0.92 threshold skips; 0.85–0.92 is a gray zone)
+        // 0.5 <= score < 0.85: potential conflict
+        const conflict: ConflictRecord = {
+          newId: id,
+          newText: rule,
+          conflictId: c.id,
+          conflictText: c.text,
+          score: c.score,
+          timestamp: Date.now(),
+        };
+        const conflictKey = [id, c.id].sort().join("::");
+        this.pendingConflicts.set(conflictKey, conflict);
+        conflictWarnings.push(
+          `⚠ Possible conflict with [${c.id.slice(0, 8)}] (similarity ${(c.score * 100).toFixed(0)}%): "${c.text.slice(0, 80)}${c.text.length > 80 ? "…" : ""}" — call synthesize_behaviors("${id}", "${c.id}") to resolve.`,
+        );
+        if (this.agent) {
+          this.agent.emit("behavior:conflict_detected", id, rule, c.id, c.text, c.score);
+        }
+      }
+    } catch (e) {
+      logger.warn(this.name, "Conflict detection failed (non-critical):", e);
+    }
+
+    const base = `Behavior saved (id: ${id}, weight: ${weight.toFixed(2)}).`;
+    if (conflictWarnings.length > 0) {
+      return [base, ...conflictWarnings].join("\n");
+    }
+    return base;
+  }
+
+  /** Public entry point for web server REST synthesize endpoint. */
+  public async synthesize(idA: string, idB: string): Promise<string> {
+    return this.handleSynthesizeBehaviors({ id_a: idA, id_b: idB });
+  }
+
+  private async handleSynthesizeBehaviors(args: any): Promise<string> {
+    const idA = String(args.id_a ?? "").trim();
+    const idB = String(args.id_b ?? "").trim();
+    if (!idA || !idB) return "Both id_a and id_b are required.";
+
+    const [memA, memB] = await Promise.all([
+      this.memoryPlugin.getMemoryById(idA),
+      this.memoryPlugin.getMemoryById(idB),
+    ]);
+    if (!memA) return `Behavior [${idA}] not found.`;
+    if (!memB) return `Behavior [${idB}] not found.`;
+
+    logger.info(this.name, `synthesize_behaviors: "${memA.text.slice(0, 60)}" ↔ "${memB.text.slice(0, 60)}"`);
+
+    const synthesisPrompt = [
+      "You are resolving a conflict between two behavioral rules for an AI assistant.",
+      "Produce a single unified rule that honors the intent of both, resolving any tension between them.",
+      "Return only the unified rule text — no explanation, no preamble.",
+      "",
+      `Rule A: ${memA.text}`,
+      `Rule B: ${memB.text}`,
+    ].join("\n");
+
+    let synthesized: string;
+    try {
+      const result = await this.llm.chat(
+        [{ role: "user", content: synthesisPrompt }],
+        "You are a concise behavioral rule synthesizer. Output only the unified rule.",
+      );
+      synthesized = result.nonReasoningContent.trim();
+      if (!synthesized) throw new Error("Empty synthesis result");
+    } catch (e) {
+      return `Synthesis failed: ${e instanceof Error ? e.message : String(e)}`;
+    }
+
+    // Save synthesized behavior with the higher weight of the two originals
+    const newWeight = Math.max(memA.weight ?? 1.0, memB.weight ?? 1.0);
+    const newId = await this.memoryPlugin.writeMemory(synthesized, "behavior", [], "BehaviorPlugin:synthesis", newWeight);
+    if (!newId) {
+      return `Synthesis complete but result was a near-duplicate of an existing behavior: "${synthesized}"`;
+    }
+
+    // Supersede both originals
+    await this.memoryPlugin.supersedeBehavior(idA, newId);
+    await this.memoryPlugin.supersedeBehavior(idB, newId);
+
+    // Remove from pending conflict queue
+    for (const key of this.pendingConflicts.keys()) {
+      if (key.includes(idA) || key.includes(idB)) {
+        this.pendingConflicts.delete(key);
+      }
+    }
+
+    return [
+      `Synthesis complete. New behavior saved (id: ${newId}, weight: ${newWeight.toFixed(2)}):`,
+      `"${synthesized}"`,
+      `Both [${idA.slice(0, 8)}] and [${idB.slice(0, 8)}] have been superseded.`,
+    ].join("\n");
+  }
+
+  private handleActivateProfile(args: any): string {
+    const profile = String(args.profile ?? "").trim();
+    if (!profile) return "Profile name cannot be empty.";
+
+    const matching = this.memoryPlugin.queryMemoriesRaw({ types: ["behavior"], tags: [profile] });
+    if (matching.length === 0) {
+      return `No behaviors found with tag "${profile}".`;
+    }
+
+    let added = 0;
+    for (const b of matching) {
+      const alreadyLoaded = this.profileBehaviors.some(pb => pb.id === b.id);
+      if (!alreadyLoaded) {
+        this.profileBehaviors.push({ id: b.id, text: b.text, weight: b.weight ?? 1.0 });
+        added++;
+      }
+    }
+
+    logger.info(this.name, `activate_profile "${profile}": loaded ${added} behavior(s)`);
+    return `Profile "${profile}" activated — ${added} behavior(s) added to always-active set (${matching.length} total in profile).`;
+  }
+
+  private handleForceBehavior(args: any): string {
+    const id = String(args.id ?? "").trim();
+    if (!id) return "Behavior ID cannot be empty.";
+    this.forcedBehaviorIds.add(id);
+    logger.info(this.name, `force_behavior: pinned [${id.slice(0, 8)}]`);
+    return `Behavior [${id.slice(0, 8)}] pinned as always-active for this session.`;
+  }
+
+  private handleSuppressBehavior(args: any): string {
+    const id = String(args.id ?? "").trim();
+    if (!id) return "Behavior ID cannot be empty.";
+    this.suppressedBehaviorIds.add(id);
+    this.forcedBehaviorIds.delete(id); // remove from forced if it was there
+    logger.info(this.name, `suppress_behavior: suppressed [${id.slice(0, 8)}]`);
+    return `Behavior [${id.slice(0, 8)}] suppressed for this session.`;
+  }
+
+  // ── Public API for web server ─────────────────────────────────────────────
+
+  /** Return pending conflicts as an array for the REST endpoint. */
+  public getConflicts(): ConflictRecord[] {
+    return Array.from(this.pendingConflicts.values()).sort((a, b) => b.timestamp - a.timestamp);
+  }
+
+  /** Dismiss a conflict from the queue without synthesizing. */
+  public dismissConflict(key: string): boolean {
+    return this.pendingConflicts.delete(key);
+  }
+}

--- a/src/plugins/CortexMemoryDatabase.ts
+++ b/src/plugins/CortexMemoryDatabase.ts
@@ -735,6 +735,13 @@ export class CortexMemoryDatabase {
     this.db.prepare("UPDATE memories SET status = ? WHERE id = ?").run(status, id);
   }
 
+  /** Mark a memory as superseded and set its forward pointer to the replacement. */
+  public setSupersededBy(oldId: string, newId: string): void {
+    this.db
+      .prepare("UPDATE memories SET status = 'superseded', superseded_by_id = ? WHERE id = ?")
+      .run(newId, oldId);
+  }
+
   /** Retrieve a memory by ID, including its tags, weight, and lineage columns. */
   public async getMemoryById(id: string): Promise<{
     id: string;

--- a/src/plugins/CortexMemoryDatabase.ts
+++ b/src/plugins/CortexMemoryDatabase.ts
@@ -170,9 +170,19 @@ export class CortexMemoryDatabase {
       this.db.run(`ALTER TABLE memory_links ADD COLUMN link_type TEXT NOT NULL DEFAULT 'related'`);
     }
 
-    // Bump schema version
+    // Bump schema version to 3
     if (version < 3) {
       this.db.run(`UPDATE schema_version SET version = 3, updated_at = ${Date.now()}`);
+    }
+
+    // Phase 6: weight column — controls behavior injection priority (0.0–1.0)
+    const freshCols2 = this.db.prepare("PRAGMA table_info(memories)").all() as { name: string }[];
+    const hasWeight = freshCols2.some(c => c.name === "weight");
+    if (!hasWeight) {
+      this.db.run(`ALTER TABLE memories ADD COLUMN weight REAL NOT NULL DEFAULT 1.0`);
+    }
+    if (version < 4) {
+      this.db.run(`UPDATE schema_version SET version = 4, updated_at = ${Date.now()}`);
     }
 
     // Phase 3 migration: strip [THOUGHT] prefix from thought memory text — idempotent
@@ -285,7 +295,7 @@ export class CortexMemoryDatabase {
     return { clause, params };
   }
 
-  /** Add a memory with an optional type, tags, source, and confidence. Returns the new memory's ID. */
+  /** Add a memory with an optional type, tags, source, confidence, and weight. Returns the new memory's ID. */
   public async addMemory(
     text: string,
     type: string = "factual",
@@ -294,6 +304,7 @@ export class CortexMemoryDatabase {
     confidence?: number,
     supersededById?: string,
     reconstructedFromId?: string,
+    weight?: number,
   ): Promise<string> {
     logger.debug("CortexDB", `addMemory type=${type}: getting embedding for "${text.slice(0, 80)}"`);
     const embedding = await this.chunkAndEmbed(text);
@@ -315,13 +326,14 @@ export class CortexMemoryDatabase {
       .prepare(
         `INSERT INTO memories
           (id, text, embedding_bin, timestamp, type, tags, status, source, confidence, scope,
-           superseded_by_id, reconstructed_from_id, version_rank)
-         VALUES (?, ?, ?, ?, ?, ?, 'active', ?, ?, 'global', ?, ?, ?)`,
+           superseded_by_id, reconstructed_from_id, version_rank, weight)
+         VALUES (?, ?, ?, ?, ?, ?, 'active', ?, ?, 'global', ?, ?, ?, ?)`,
       )
       .run(
         id, text, embeddingBin, Date.now(), type,
         JSON.stringify(tags), source ?? null, confidence ?? 1.0,
         supersededById ?? null, reconstructedFromId ?? null, versionRank,
+        weight ?? 1.0,
       );
 
     // If superseding, mark the old memory and set its forward pointer
@@ -367,35 +379,35 @@ export class CortexMemoryDatabase {
     threshold: number,
     type: string | string[] | undefined,
     includeEmbeddings: true,
-  ): Array<{ id: string; text: string; score: number; embedding: Float32Array }>;
+  ): Array<{ id: string; text: string; score: number; weight: number; embedding: Float32Array }>;
   public searchWithEmbedding(
     queryEmbedding: number[],
     limit?: number,
     threshold?: number,
     type?: string | string[],
     includeEmbeddings?: false | undefined,
-  ): Array<{ id: string; text: string; score: number }>;
+  ): Array<{ id: string; text: string; score: number; weight: number }>;
   public searchWithEmbedding(
     queryEmbedding: number[],
     limit: number = 5,
     threshold: number = 0.5,
     type?: string | string[],
     includeEmbeddings?: boolean,
-  ): Array<{ id: string; text: string; score: number; embedding?: Float32Array }> {
-    let rows: { id: string; text: string; embedding_bin: Buffer }[];
+  ): Array<{ id: string; text: string; score: number; weight: number; embedding?: Float32Array }> {
+    let rows: { id: string; text: string; weight: number; embedding_bin: Buffer }[];
     if (Array.isArray(type)) {
       const placeholders = type.map(() => "?").join(", ");
       rows = this.db
-        .prepare(`SELECT id, text, embedding_bin FROM memories WHERE type IN (${placeholders}) AND status = 'active'`)
-        .all(...type) as { id: string; text: string; embedding_bin: Buffer }[];
+        .prepare(`SELECT id, text, weight, embedding_bin FROM memories WHERE type IN (${placeholders}) AND status = 'active'`)
+        .all(...type) as { id: string; text: string; weight: number; embedding_bin: Buffer }[];
     } else {
       rows = (
         type
           ? this.db
-              .prepare("SELECT id, text, embedding_bin FROM memories WHERE type = ? AND status = 'active'")
+              .prepare("SELECT id, text, weight, embedding_bin FROM memories WHERE type = ? AND status = 'active'")
               .all(type)
-          : this.db.prepare("SELECT id, text, embedding_bin FROM memories WHERE status = 'active'").all()
-      ) as { id: string; text: string; embedding_bin: Buffer }[];
+          : this.db.prepare("SELECT id, text, weight, embedding_bin FROM memories WHERE status = 'active'").all()
+      ) as { id: string; text: string; weight: number; embedding_bin: Buffer }[];
     }
 
     const results = rows
@@ -406,15 +418,15 @@ export class CortexMemoryDatabase {
         const emb = bufferToFloat32Array(row.embedding_bin);
         const score = this.cosSim(queryEmbedding, emb);
         if (includeEmbeddings) {
-          return { id: row.id, text: row.text, score, embedding: emb };
+          return { id: row.id, text: row.text, score, weight: row.weight ?? 1.0, embedding: emb };
         }
-        return { id: row.id, text: row.text, score };
+        return { id: row.id, text: row.text, score, weight: row.weight ?? 1.0 };
       })
       .filter(r => r.score >= threshold)
       .sort((a, b) => b.score - a.score)
       .slice(0, limit);
 
-    return results as Array<{ id: string; text: string; score: number; embedding?: Float32Array }>;
+    return results as Array<{ id: string; text: string; score: number; weight: number; embedding?: Float32Array }>;
   }
 
   /** Search memories by embedding similarity and return results with retrieval metadata. */
@@ -462,7 +474,7 @@ export class CortexMemoryDatabase {
   /** Filter memories by metadata. Returns results ordered by recency. */
   public queryMemories(
     filter: MemoryFilter,
-  ): Array<{ id: string; text: string; timestamp: number; type: string; tags: string[] }> {
+  ): Array<{ id: string; text: string; timestamp: number; type: string; tags: string[]; weight: number }> {
     const limit = filter.limit ?? 20;
     const { clause, params } = this.buildWhereClause(filter);
 
@@ -477,7 +489,7 @@ export class CortexMemoryDatabase {
       allParams.push(escapeFtsQuery(filter.contains));
     }
 
-    const sql = `SELECT m.id, m.text, m.timestamp, m.type, m.tags FROM memories m ${whereClause} ORDER BY m.timestamp DESC LIMIT ?`;
+    const sql = `SELECT m.id, m.text, m.timestamp, m.type, m.tags, m.weight FROM memories m ${whereClause} ORDER BY m.timestamp DESC LIMIT ?`;
     allParams.push(limit);
 
     const rows = this.db.prepare(sql).all(...allParams) as {
@@ -486,11 +498,13 @@ export class CortexMemoryDatabase {
       timestamp: number;
       type: string;
       tags: string;
+      weight: number;
     }[];
 
     return rows.map(row => ({
       ...row,
       tags: JSON.parse(row.tags ?? "[]") as string[],
+      weight: row.weight ?? 1.0,
     }));
   }
 
@@ -721,7 +735,7 @@ export class CortexMemoryDatabase {
     this.db.prepare("UPDATE memories SET status = ? WHERE id = ?").run(status, id);
   }
 
-  /** Retrieve a memory by ID, including its tags and lineage columns. */
+  /** Retrieve a memory by ID, including its tags, weight, and lineage columns. */
   public async getMemoryById(id: string): Promise<{
     id: string;
     text: string;
@@ -729,23 +743,29 @@ export class CortexMemoryDatabase {
     type: string;
     tags: string[];
     status: string;
+    weight: number;
     superseded_by_id: string | null;
     reconstructed_from_id: string | null;
     version_rank: number;
   } | null> {
     const row = this.db
       .prepare(
-        `SELECT id, text, timestamp, type, tags, status,
+        `SELECT id, text, timestamp, type, tags, status, weight,
                 superseded_by_id, reconstructed_from_id, version_rank
          FROM memories WHERE id = ?`,
       )
       .get(id) as {
         id: string; text: string; timestamp: number; type: string; tags: string;
-        status: string; superseded_by_id: string | null;
+        status: string; weight: number; superseded_by_id: string | null;
         reconstructed_from_id: string | null; version_rank: number;
       } | null;
     if (!row) return null;
-    return { ...row, tags: JSON.parse(row.tags ?? "[]") as string[] };
+    return { ...row, tags: JSON.parse(row.tags ?? "[]") as string[], weight: row.weight ?? 1.0 };
+  }
+
+  /** Update the weight of a behavior memory. */
+  public updateMemoryWeight(id: string, weight: number): void {
+    this.db.prepare("UPDATE memories SET weight = ? WHERE id = ?").run(Math.max(0, Math.min(1, weight)), id);
   }
 
   /** Follow the supersession and reconstruction chain for a memory in both directions. */

--- a/src/plugins/CortexMemoryPlugin.ts
+++ b/src/plugins/CortexMemoryPlugin.ts
@@ -40,9 +40,6 @@ export class CortexMemoryPlugin implements AgentPlugin {
   /** Text of memories saved this turn, keyed by ID. Used by onMessage() for per-pair conflict classification. */
   private savedThisTurnTexts: Map<string, string> = new Map();
 
-  /** Cached core behavior memories (tagged "core"), invalidated when a core behavior is saved or deleted. */
-  private coreBehaviorCache: Array<{ id: string; text: string }> | null = null;
-
   /** Side-channel metadata from the most recent memory search (keyed by tool name). */
   public searchMetaBuffer: Map<string, SearchMeta> = new Map();
 
@@ -81,6 +78,34 @@ export class CortexMemoryPlugin implements AgentPlugin {
     });
   }
 
+  // ─── Embedding cache sharing ─────────────────────────────────────────────────
+
+  /**
+   * Return the cached embedding for `text` if available, otherwise compute and cache it.
+   * BehaviorPlugin calls this to avoid a redundant embedding round-trip when both plugins
+   * process the same user input in the same turn.
+   */
+  public async getOrComputeEmbedding(text: string): Promise<number[]> {
+    if (this.embeddingCache && this.embeddingCache.query === text) {
+      return this.embeddingCache.embedding;
+    }
+    const embedding = await this.db.getEmbedding(text);
+    this.embeddingCache = { query: text, embedding };
+    return embedding;
+  }
+
+  /**
+   * Semantic search over behavior memories — used by BehaviorPlugin for contextual retrieval.
+   * Returns results including weight so BehaviorPlugin can apply weight-based thresholds.
+   */
+  public searchBehaviorsWithEmbedding(
+    embedding: number[],
+    limit: number,
+    threshold: number,
+  ): Array<{ id: string; text: string; score: number; weight: number }> {
+    return this.db.searchWithEmbedding(embedding, limit, threshold, "behavior");
+  }
+
   // ─── Programmatic write/read interface for internal plugins ──────────────────
   //
   // These methods are the ONLY sanctioned way for other plugins to interact with
@@ -97,7 +122,7 @@ export class CortexMemoryPlugin implements AgentPlugin {
    *   returns null (skipping the write) if a near-duplicate already exists.
    * - For `factual` / `procedure` types: runs post-write near-dup superseding at 0.9.
    * - Updates `savedThisTurn` so that `onMessage` conflict resolution fires correctly.
-   * - Invalidates `coreBehaviorCache` when a core-tagged behavior is saved.
+   * - Updates `savedThisTurn` so behavior conflict detection fires correctly.
    *
    * @returns The new memory ID, or null if the write was skipped due to dedup.
    */
@@ -106,6 +131,7 @@ export class CortexMemoryPlugin implements AgentPlugin {
     type: "factual" | "thought" | "behavior" | "procedure",
     tags: string[] = [],
     source?: string,
+    weight?: number,
   ): Promise<string | null> {
     if (text.length > MAX_CONTENT_LENGTH) {
       logger.warn(this.name, `writeMemory: content too long (${text.length} chars), truncating to ${MAX_CONTENT_LENGTH}`);
@@ -124,14 +150,9 @@ export class CortexMemoryPlugin implements AgentPlugin {
       }
     }
 
-    const id = await this.db.addMemory(text, type, tags, source);
+    const id = await this.db.addMemory(text, type, tags, source, undefined, undefined, undefined, weight);
     this.savedThisTurn.add(id);
     this.savedThisTurnTexts.set(id, text);
-
-    // Invalidate core behavior cache when a core-tagged behavior is saved
-    if (type === "behavior" && tags.includes("core")) {
-      this.coreBehaviorCache = null;
-    }
 
     // Factual/procedure: post-write near-dup superseding at 0.9
     if (type === "factual" || type === "procedure") {
@@ -157,8 +178,29 @@ export class CortexMemoryPlugin implements AgentPlugin {
    * Raw memory query by metadata filter. Returns the full row array.
    * Used by MetacognitionPlugin to reconstruct correction history on init.
    */
-  public queryMemoriesRaw(filter: MemoryFilter): Array<{ id: string; text: string; timestamp: number; type: string; tags: string[] }> {
+  public queryMemoriesRaw(filter: MemoryFilter): Array<{ id: string; text: string; timestamp: number; type: string; tags: string[]; weight: number }> {
     return this.db.queryMemories(filter);
+  }
+
+  /**
+   * Mark a memory as superseded by another. Used by BehaviorPlugin after synthesis.
+   */
+  public async supersedeBehavior(oldId: string, _newId: string): Promise<void> {
+    await this.db.updateMemoryStatus(oldId, "superseded");
+  }
+
+  /**
+   * Update the weight of a behavior memory. Used by BehaviorPlugin.
+   */
+  public updateBehaviorWeight(id: string, weight: number): void {
+    this.db.updateMemoryWeight(id, weight);
+  }
+
+  /**
+   * Edit a memory's text and re-embed. Used by the web UI REST endpoint.
+   */
+  public async editMemory(id: string, newText: string): Promise<void> {
+    await this.db.updateMemoryText(id, newText);
   }
 
   /**
@@ -211,25 +253,27 @@ export class CortexMemoryPlugin implements AgentPlugin {
   public async deleteMemoryById(id: string): Promise<void> {
     const existing = await this.db.getMemoryById(id);
     if (!existing) return;
-    if (existing.type === "behavior" && (existing.tags ?? []).includes("core")) {
-      this.coreBehaviorCache = null;
-    }
     await this.db.deleteMemory(id);
   }
 
   // ─────────────────────────────────────────────────────────────────────────────
 
   async getSystemPromptFragment(context?: string): Promise<string> {
+    // Pre-compute embedding for this turn so getContext() can reuse it without a second round-trip.
+    if (context?.trim() && (!this.embeddingCache || this.embeddingCache.query !== context)) {
+      this.embeddingCache = { query: context, embedding: await this.db.getEmbedding(context) };
+    }
+
     const parts = [
       "## Memory System",
       "You have a long-term memory system with four types of memories:",
       "- **factual**: specific details from conversations, decisions, established facts.",
       "- **thought**: your internal reasoning and reflections (written by your thought system).",
-      "- **behavior**: learned preferences and behavioral rules (injected as active instructions).",
+      "- **behavior**: learned preferences and behavioral rules (managed by the Behavior system).",
       "- **procedure**: step-by-step instructions for accomplishing a task you have previously solved.",
       "Relevant factual memories and procedures are automatically surfaced in your context at the start of each turn — check there before calling search_memory.",
       "Use `save_memory` to preserve important facts or decisions.",
-      "Use `save_behavior` to record a persistent behavioral rule you want to follow on every future turn. Pass `core: true` for universal rules that should always be active (e.g. formatting, tone). Omit or pass `core: false` for context-specific rules that will be surfaced when relevant.",
+      "Use `save_behavior` to record a persistent behavioral rule. See Behavior System instructions for details.",
       "Use `save_procedure` after successfully completing a non-trivial task to record the steps taken.",
       "Use `edit_memory` to update the text of an existing memory by its ID.",
       "Use `delete_memory` to remove a memory. Single form: `{ id }`. Batch form: `{ ids: [id1, id2, ...] }` — deletes multiple memories in one call and triggers one cache invalidation regardless of how many IDs are provided.",
@@ -241,56 +285,6 @@ export class CortexMemoryPlugin implements AgentPlugin {
       "Use `aggregate_memories` to understand the shape and distribution of your memories.",
       "Use `get_memory_timeline` to retrieve memories in chronological order.",
     ];
-
-    try {
-      // Core behaviors: always active, cached until a core behavior is saved or deleted
-      if (this.coreBehaviorCache === null) {
-        const rows = this.db.queryMemories({
-          types: ["behavior"],
-          tags: ["core"],
-          limit: 50,
-        });
-        this.coreBehaviorCache = rows.map(r => ({ id: r.id, text: r.text }));
-      }
-
-      // Contextual behaviors: semantically matched to the current input
-      let contextualBehaviors: Array<{ id: string; text: string }> = [];
-      const coreIds = new Set(this.coreBehaviorCache.map(b => b.id));
-
-      if (context?.trim()) {
-        // Populate the cache if this is the first call this turn or the query changed.
-        // getContext() runs next (BaseAgent calls fragment before context within each plugin)
-        // and will reuse this embedding rather than issuing a second LLM request.
-        if (!this.embeddingCache || this.embeddingCache.query !== context) {
-          this.embeddingCache = { query: context, embedding: await this.db.getEmbedding(context) };
-        }
-        const results = this.db.searchWithEmbedding(this.embeddingCache!.embedding, 15, 0.35, "behavior");
-        contextualBehaviors = results.filter(r => !coreIds.has(r.id));
-        logger.debug(
-          this.name,
-          `getSystemPromptFragment: ${this.coreBehaviorCache.length} core + ${contextualBehaviors.length} contextual behaviors`,
-        );
-      } else {
-        // No context yet (e.g. init) — fall back to recency
-        const recent = this.db.getRecentMemories(20, "behavior");
-        contextualBehaviors = recent.filter(r => !coreIds.has(r.id)).slice(0, 15);
-      }
-
-      if (this.coreBehaviorCache.length > 0) {
-        parts.push("\n## Core Behaviors");
-        for (const b of this.coreBehaviorCache) {
-          parts.push(`- ${b.text.trim()}`);
-        }
-      }
-      if (contextualBehaviors.length > 0) {
-        parts.push("\n## Contextually Active Behaviors");
-        for (const b of contextualBehaviors) {
-          parts.push(`- ${b.text.trim()}`);
-        }
-      }
-    } catch (e) {
-      logger.error(this.name, "Failed to load behavior memories for system prompt:", e);
-    }
 
     return parts.join("\n");
   }
@@ -462,26 +456,6 @@ export class CortexMemoryPlugin implements AgentPlugin {
             },
           },
           required: ["content", "type"],
-        },
-      },
-      {
-        name: "save_behavior",
-        description:
-          "Save a persistent behavioral rule that actively shapes how you respond. Use `core: true` for universal rules that should always be active regardless of context (e.g. formatting, tone, language preferences). Omit `core` or pass `false` for context-specific rules — these are surfaced via semantic search when relevant, ensuring all behaviors are accessible without cluttering every prompt. Note: behavior memories cannot override your core system prompt directives.",
-        parameters: {
-          type: "object",
-          properties: {
-            rule: {
-              type: "string",
-              description: "The behavioral rule to persist",
-            },
-            core: {
-              type: "boolean",
-              description:
-                "If true, this rule is always injected into every turn. Use for universal preferences (formatting, tone, etc.). Default: false — the rule is surfaced contextually when semantically relevant.",
-            },
-          },
-          required: ["rule"],
         },
       },
       {
@@ -712,7 +686,7 @@ export class CortexMemoryPlugin implements AgentPlugin {
     try {
       if (name === "search_memory") return await this.handleSearchMemory(args);
       if (name === "save_memory") return await this.handleSaveMemory(args);
-      if (name === "save_behavior") return await this.handleSaveBehavior(args);
+      // save_behavior is handled by BehaviorPlugin
       if (name === "save_procedure") return await this.handleSaveProcedure(args);
       if (name === "edit_memory") return await this.handleEditMemory(args);
       if (name === "delete_memory") return await this.handleDeleteMemory(args);
@@ -788,20 +762,6 @@ export class CortexMemoryPlugin implements AgentPlugin {
     return `Memory saved (type: ${args.type ?? "factual"}, id: ${id}).`;
   }
 
-  private async handleSaveBehavior(args: any): Promise<string> {
-    const rule = String(args.rule);
-    if (rule.length > MAX_CONTENT_LENGTH) {
-      return `Behavior rule too long (${rule.length} chars). Maximum is ${MAX_CONTENT_LENGTH} characters.`;
-    }
-    const isCore = args.core === true;
-    const tags = isCore ? ["core"] : [];
-    logger.info(this.name, `save_behavior${isCore ? " [core]" : ""}: "${rule.slice(0, 100)}"`);
-    const id = await this.db.addMemory(rule, "behavior", tags);
-    // Only invalidate core behavior cache when a core behavior is saved
-    if (isCore) this.coreBehaviorCache = null;
-    return `Memory saved (type: behavior, core: ${isCore}, id: ${id}).`;
-  }
-
   private async handleSaveProcedure(args: any): Promise<string> {
     const goal = String(args.goal);
     const steps = String(args.steps);
@@ -822,11 +782,7 @@ export class CortexMemoryPlugin implements AgentPlugin {
     logger.info(this.name, `edit_memory id=${args.id}: "${content.slice(0, 100)}"`);
     const existing = await this.db.getMemoryById(args.id);
     if (!existing) return `No memory found with id ${args.id}.`;
-    // Invalidate core behavior cache only if editing a core behavior
-    const isEditingCoreBehavior =
-      existing.type === "behavior" && (existing.tags ?? []).includes("core");
     await this.db.updateMemoryText(args.id, content);
-    if (isEditingCoreBehavior) this.coreBehaviorCache = null;
     logger.info(this.name, `edit_memory SUCCESS id=${args.id}`);
     return `Memory ${args.id} updated.`;
   }
@@ -837,7 +793,6 @@ export class CortexMemoryPlugin implements AgentPlugin {
       let deleted = 0;
       let missing = 0;
       let invalid = 0;
-      let invalidateCache = false;
       for (const id of args.ids) {
         if (typeof id !== "string" || !id.trim()) {
           invalid++;
@@ -848,13 +803,9 @@ export class CortexMemoryPlugin implements AgentPlugin {
           missing++;
           continue;
         }
-        if (existing.type === "behavior" && (existing.tags ?? []).includes("core")) {
-          invalidateCache = true;
-        }
         await this.db.deleteMemory(id);
         deleted++;
       }
-      if (invalidateCache) this.coreBehaviorCache = null;
       return `Batch delete: ${deleted} deleted, ${missing} not found, ${invalid} invalid out of ${args.ids.length} requested.`;
     }
 
@@ -870,10 +821,7 @@ export class CortexMemoryPlugin implements AgentPlugin {
     logger.info(this.name, `delete_memory id=${args.id}`);
     const existing = await this.db.getMemoryById(args.id);
     if (!existing) return `No memory found with id ${args.id}.`;
-    const wasCoreBehavior =
-      existing.type === "behavior" && (existing.tags ?? []).includes("core");
     await this.db.deleteMemory(args.id);
-    if (wasCoreBehavior) this.coreBehaviorCache = null;
     return `Memory ${args.id} deleted.`;
   }
 

--- a/src/plugins/CortexMemoryPlugin.ts
+++ b/src/plugins/CortexMemoryPlugin.ts
@@ -185,8 +185,8 @@ export class CortexMemoryPlugin implements AgentPlugin {
   /**
    * Mark a memory as superseded by another. Used by BehaviorPlugin after synthesis.
    */
-  public async supersedeBehavior(oldId: string, _newId: string): Promise<void> {
-    await this.db.updateMemoryStatus(oldId, "superseded");
+  public async supersedeBehavior(oldId: string, newId: string): Promise<void> {
+    this.db.setSupersededBy(oldId, newId);
   }
 
   /**

--- a/src/ui/web/WebApp.tsx
+++ b/src/ui/web/WebApp.tsx
@@ -10,6 +10,49 @@ import type {
 
 // ── Types ─────────────────────────────────────────────────────────────────────
 
+interface BehaviorRecord {
+  id: string;
+  text: string;
+  weight: number;
+}
+
+interface ContextualBehaviorRecord extends BehaviorRecord {
+  score: number;
+}
+
+interface ConflictRecord {
+  newId: string;
+  newText: string;
+  conflictId: string;
+  conflictText: string;
+  score: number;
+  timestamp: number;
+}
+
+interface MemoryRow {
+  id: string;
+  text: string;
+  timestamp: number;
+  type: string;
+  tags: string[];
+  weight: number;
+}
+
+interface TraceEntry {
+  id: string;
+  score: number;
+}
+
+interface RetrievalTrace {
+  timestamp: number;
+  query_length: number;
+  factual: TraceEntry[];
+  procedure: TraceEntry[];
+  recent_thoughts: Array<{ id: string }>;
+}
+
+type PanelId = "memory" | "behaviors" | "conflicts" | "agents" | "trace";
+
 type WsMessage =
   | {
       type: "snapshot";
@@ -32,7 +75,20 @@ type WsMessage =
       };
     }
   | { type: "model_changed"; model: string }
-  | { type: "system_prompt"; systemPrompt: string; model: string };
+  | { type: "system_prompt"; systemPrompt: string; model: string }
+  | {
+      type: "behavior_conflict";
+      newId: string;
+      newText: string;
+      conflictId: string;
+      conflictText: string;
+      score: number;
+    }
+  | {
+      type: "behaviors_loaded";
+      core: BehaviorRecord[];
+      contextual: ContextualBehaviorRecord[];
+    };
 
 interface PermissionRequest {
   agentName: string;
@@ -210,12 +266,10 @@ function StatusArea({
   state,
   activeTools,
   dynamicAgents,
-  model,
 }: {
   state: AgentState;
   activeTools: ActiveTool[];
   dynamicAgents: DynamicAgentRecord[];
-  model: string;
 }) {
   const isThinking = state === "thinking";
   const activeAgents = dynamicAgents.filter((a) => a.state !== "idle");
@@ -238,11 +292,6 @@ function StatusArea({
             "ready"
           )}
         </span>
-        {model && (
-          <span className="header-model" style={{ marginLeft: "auto" }}>
-            {model}
-          </span>
-        )}
       </div>
 
       {isThinking && activeTools.length > 0 && (
@@ -390,6 +439,463 @@ function ChatInput({
   );
 }
 
+// ── Sidebar panels ────────────────────────────────────────────────────────────
+
+function MemoryPanel() {
+  const [memories, setMemories] = useState<MemoryRow[]>([]);
+  const [loading, setLoading] = useState(false);
+  const [typeFilter, setTypeFilter] = useState("all");
+  const [search, setSearch] = useState("");
+  const [expandedId, setExpandedId] = useState<string | null>(null);
+  const [editingId, setEditingId] = useState<string | null>(null);
+  const [editText, setEditText] = useState("");
+  const searchTimeout = useRef<ReturnType<typeof setTimeout> | null>(null);
+
+  const load = useCallback(async (type: string, q: string) => {
+    setLoading(true);
+    try {
+      const params = new URLSearchParams({ limit: "50" });
+      if (type !== "all") params.set("type", type);
+      if (q.trim()) params.set("search", q.trim());
+      const res = await fetch(`/api/memories?${params}`);
+      const data = await res.json() as MemoryRow[];
+      setMemories(data);
+    } catch {
+      // non-critical
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    load(typeFilter, search);
+  }, [typeFilter, load]);
+
+  const handleSearch = useCallback((q: string) => {
+    setSearch(q);
+    if (searchTimeout.current) clearTimeout(searchTimeout.current);
+    searchTimeout.current = setTimeout(() => load(typeFilter, q), 400);
+  }, [typeFilter, load]);
+
+  const handleEdit = useCallback(async (id: string) => {
+    if (!editText.trim()) return;
+    await fetch(`/api/memories/${id}`, {
+      method: "PATCH",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ content: editText }),
+    });
+    setEditingId(null);
+    load(typeFilter, search);
+  }, [editText, typeFilter, search, load]);
+
+  const handleDelete = useCallback(async (id: string) => {
+    if (!confirm("Delete this memory?")) return;
+    await fetch(`/api/memories/${id}`, { method: "DELETE" });
+    setMemories(prev => prev.filter(m => m.id !== id));
+    if (expandedId === id) setExpandedId(null);
+  }, [expandedId]);
+
+  return (
+    <div className="panel">
+      <div className="panel-controls">
+        <select
+          className="panel-select"
+          value={typeFilter}
+          onChange={e => { setTypeFilter(e.target.value); }}
+        >
+          <option value="all">All types</option>
+          <option value="factual">Factual</option>
+          <option value="behavior">Behavior</option>
+          <option value="procedure">Procedure</option>
+          <option value="thought">Thought</option>
+        </select>
+        <input
+          className="panel-input"
+          placeholder="Search…"
+          value={search}
+          onChange={e => handleSearch(e.target.value)}
+        />
+        <button className="panel-btn" onClick={() => load(typeFilter, search)}>↺</button>
+      </div>
+
+      {loading && <div className="panel-loading">Loading…</div>}
+
+      <div className="panel-list">
+        {memories.map(m => (
+          <div key={m.id} className="memory-item">
+            <div
+              className="memory-header"
+              onClick={() => setExpandedId(expandedId === m.id ? null : m.id)}
+            >
+              <span className="memory-type">{m.type}</span>
+              <span className="memory-id">[{m.id.slice(0, 8)}]</span>
+              <span className="memory-date">
+                {new Date(m.timestamp).toLocaleDateString()}
+              </span>
+              {m.type === "behavior" && (
+                <span className="memory-weight">w:{m.weight?.toFixed(1) ?? "?"}</span>
+              )}
+            </div>
+            {expandedId === m.id && (
+              <div className="memory-body">
+                {editingId === m.id ? (
+                  <>
+                    <textarea
+                      className="memory-edit-area"
+                      value={editText}
+                      onChange={e => setEditText(e.target.value)}
+                      rows={4}
+                    />
+                    <div className="memory-actions">
+                      <button className="panel-btn panel-btn--green" onClick={() => handleEdit(m.id)}>Save</button>
+                      <button className="panel-btn" onClick={() => setEditingId(null)}>Cancel</button>
+                    </div>
+                  </>
+                ) : (
+                  <>
+                    <div className="memory-text">{m.text}</div>
+                    {m.tags.length > 0 && (
+                      <div className="memory-tags">
+                        {m.tags.map(t => <span key={t} className="tag">{t}</span>)}
+                      </div>
+                    )}
+                    <div className="memory-actions">
+                      <button
+                        className="panel-btn"
+                        onClick={() => { setEditingId(m.id); setEditText(m.text); }}
+                      >Edit</button>
+                      <button
+                        className="panel-btn panel-btn--red"
+                        onClick={() => handleDelete(m.id)}
+                      >Delete</button>
+                    </div>
+                  </>
+                )}
+              </div>
+            )}
+          </div>
+        ))}
+        {!loading && memories.length === 0 && (
+          <div className="panel-empty">No memories found.</div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+function BehaviorsPanel({
+  core,
+  contextual,
+}: {
+  core: BehaviorRecord[];
+  contextual: ContextualBehaviorRecord[];
+}) {
+  return (
+    <div className="panel">
+      {core.length === 0 && contextual.length === 0 && (
+        <div className="panel-empty">No behaviors loaded yet. Send a message to trigger behavior retrieval.</div>
+      )}
+      {core.length > 0 && (
+        <>
+          <div className="panel-section-label">Always active ({core.length})</div>
+          {core.map(b => (
+            <div key={b.id} className="behavior-item behavior-item--core">
+              <div className="behavior-meta">
+                <span className="memory-id">[{b.id.slice(0, 8)}]</span>
+                <span className="memory-weight">w:{b.weight.toFixed(1)}</span>
+              </div>
+              <div className="behavior-text">{b.text}</div>
+            </div>
+          ))}
+        </>
+      )}
+      {contextual.length > 0 && (
+        <>
+          <div className="panel-section-label">This turn ({contextual.length})</div>
+          {contextual.map(b => (
+            <div key={b.id} className="behavior-item">
+              <div className="behavior-meta">
+                <span className="memory-id">[{b.id.slice(0, 8)}]</span>
+                <span className="memory-weight">w:{b.weight.toFixed(1)}</span>
+                <span className="behavior-score">sim:{b.score.toFixed(2)}</span>
+              </div>
+              <div className="behavior-text">{b.text}</div>
+            </div>
+          ))}
+        </>
+      )}
+    </div>
+  );
+}
+
+function ConflictsPanel({
+  conflicts,
+  onDismiss,
+  onSynthesize,
+}: {
+  conflicts: ConflictRecord[];
+  onDismiss: (c: ConflictRecord) => void;
+  onSynthesize: (c: ConflictRecord) => Promise<void>;
+}) {
+  const [synthesizing, setSynthesizing] = useState<string | null>(null);
+  const [results, setResults] = useState<Record<string, string>>({});
+
+  const handleSynthesize = async (c: ConflictRecord) => {
+    const key = `${c.newId}::${c.conflictId}`;
+    setSynthesizing(key);
+    try {
+      const res = await fetch("/api/behaviors/synthesize", {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify({ id_a: c.newId, id_b: c.conflictId }),
+      });
+      const data = await res.json() as { result?: string; error?: string };
+      setResults(prev => ({ ...prev, [key]: data.result ?? data.error ?? "Done." }));
+      await onSynthesize(c);
+    } catch (e) {
+      setResults(prev => ({ ...prev, [key]: String(e) }));
+    } finally {
+      setSynthesizing(null);
+    }
+  };
+
+  if (conflicts.length === 0) {
+    return (
+      <div className="panel">
+        <div className="panel-empty">No pending conflicts.</div>
+      </div>
+    );
+  }
+
+  return (
+    <div className="panel">
+      {conflicts.map(c => {
+        const key = `${c.newId}::${c.conflictId}`;
+        const isBusy = synthesizing === key;
+        const result = results[key];
+        return (
+          <div key={key} className="conflict-item">
+            <div className="conflict-score">
+              Similarity: {(c.score * 100).toFixed(0)}%
+            </div>
+            <div className="conflict-pair">
+              <div className="conflict-behavior">
+                <span className="conflict-label">New</span>
+                <span className="memory-id">[{c.newId.slice(0, 8)}]</span>
+                <div className="conflict-text">{c.newText}</div>
+              </div>
+              <div className="conflict-behavior">
+                <span className="conflict-label">Conflicts with</span>
+                <span className="memory-id">[{c.conflictId.slice(0, 8)}]</span>
+                <div className="conflict-text">{c.conflictText}</div>
+              </div>
+            </div>
+            {result && (
+              <div className="conflict-result">{result}</div>
+            )}
+            {!result && (
+              <div className="conflict-actions">
+                <button
+                  className="panel-btn panel-btn--green"
+                  onClick={() => handleSynthesize(c)}
+                  disabled={isBusy}
+                >
+                  {isBusy ? "Synthesizing…" : "Synthesize"}
+                </button>
+                <button
+                  className="panel-btn"
+                  onClick={() => onDismiss(c)}
+                  disabled={isBusy}
+                >
+                  Dismiss
+                </button>
+              </div>
+            )}
+          </div>
+        );
+      })}
+    </div>
+  );
+}
+
+function AgentsPanel({ agents }: { agents: DynamicAgentRecord[] }) {
+  if (agents.length === 0) {
+    return (
+      <div className="panel">
+        <div className="panel-empty">No dynamic agents spawned yet.</div>
+      </div>
+    );
+  }
+  return (
+    <div className="panel">
+      {agents.map(a => (
+        <div key={a.name} className="agent-item">
+          <div className="agent-header">
+            <span className="agent-name">{a.name}</span>
+            <span className={`agent-state agent-state--${a.state}`}>{a.state}</span>
+          </div>
+          <div className="agent-meta">
+            <span className="agent-type">{(a as any).type ?? "headless"}</span>
+            {a.createdAt && (
+              <span className="agent-date">
+                {new Date(a.createdAt).toLocaleTimeString()}
+              </span>
+            )}
+          </div>
+          {(a as any).capabilities && (
+            <div className="memory-tags">
+              {((a as any).capabilities as string[]).map((cap: string) => (
+                <span key={cap} className="tag">{cap}</span>
+              ))}
+            </div>
+          )}
+        </div>
+      ))}
+    </div>
+  );
+}
+
+function TracePanel() {
+  const [trace, setTrace] = useState<RetrievalTrace | null>(null);
+  const [loading, setLoading] = useState(false);
+
+  const load = useCallback(async () => {
+    setLoading(true);
+    try {
+      const res = await fetch("/api/trace/last");
+      const data = await res.json() as RetrievalTrace | null;
+      setTrace(data);
+    } catch {
+      // non-critical
+    } finally {
+      setLoading(false);
+    }
+  }, []);
+
+  return (
+    <div className="panel">
+      <div className="panel-controls">
+        <button className="panel-btn" onClick={load} disabled={loading}>
+          {loading ? "Loading…" : "↺ Refresh trace"}
+        </button>
+      </div>
+      {!trace && !loading && (
+        <div className="panel-empty">Click refresh to load the last retrieval trace.</div>
+      )}
+      {trace && (
+        <>
+          <div className="panel-section-label">
+            Query length: {trace.query_length} chars
+          </div>
+          {trace.factual.length > 0 && (
+            <>
+              <div className="panel-section-label">Factual memories ({trace.factual.length})</div>
+              {trace.factual.map(f => (
+                <div key={f.id} className="trace-item">
+                  <span className="memory-id">[{f.id.slice(0, 8)}]</span>
+                  <span className="behavior-score">sim:{f.score.toFixed(3)}</span>
+                </div>
+              ))}
+            </>
+          )}
+          {trace.procedure.length > 0 && (
+            <>
+              <div className="panel-section-label">Procedures ({trace.procedure.length})</div>
+              {trace.procedure.map(p => (
+                <div key={p.id} className="trace-item">
+                  <span className="memory-id">[{p.id.slice(0, 8)}]</span>
+                  <span className="behavior-score">sim:{p.score.toFixed(3)}</span>
+                </div>
+              ))}
+            </>
+          )}
+          {trace.recent_thoughts.length > 0 && (
+            <>
+              <div className="panel-section-label">Recent thoughts ({trace.recent_thoughts.length})</div>
+              {trace.recent_thoughts.map(t => (
+                <div key={t.id} className="trace-item">
+                  <span className="memory-id">[{t.id.slice(0, 8)}]</span>
+                </div>
+              ))}
+            </>
+          )}
+        </>
+      )}
+    </div>
+  );
+}
+
+// ── Sidebar ───────────────────────────────────────────────────────────────────
+
+function Sidebar({
+  panels,
+  conflicts,
+  coreBehaviors,
+  contextualBehaviors,
+  dynamicAgents,
+  onDismissConflict,
+  onSynthesize,
+}: {
+  panels: PanelId[];
+  conflicts: ConflictRecord[];
+  coreBehaviors: BehaviorRecord[];
+  contextualBehaviors: ContextualBehaviorRecord[];
+  dynamicAgents: DynamicAgentRecord[];
+  onDismissConflict: (c: ConflictRecord) => void;
+  onSynthesize: (c: ConflictRecord) => Promise<void>;
+}) {
+  const [activeTab, setActiveTab] = useState<PanelId>(panels[0] ?? "memory");
+
+  // Make sure activeTab stays valid if panels change
+  useEffect(() => {
+    if (!panels.includes(activeTab) && panels.length > 0) {
+      setActiveTab(panels[0]!);
+    }
+  }, [panels, activeTab]);
+
+  const tabLabels: Record<PanelId, string> = {
+    memory: "Memory",
+    behaviors: "Behaviors",
+    conflicts: "Conflicts",
+    agents: "Agents",
+    trace: "Trace",
+  };
+
+  return (
+    <div className="sidebar">
+      <div className="sidebar-tabs">
+        {panels.map(p => (
+          <button
+            key={p}
+            className={`sidebar-tab ${activeTab === p ? "sidebar-tab--active" : ""}`}
+            onClick={() => setActiveTab(p)}
+          >
+            {tabLabels[p]}
+            {p === "conflicts" && conflicts.length > 0 && (
+              <span className="tab-badge">{conflicts.length}</span>
+            )}
+          </button>
+        ))}
+      </div>
+      <div className="sidebar-content">
+        {activeTab === "memory" && <MemoryPanel />}
+        {activeTab === "behaviors" && (
+          <BehaviorsPanel core={coreBehaviors} contextual={contextualBehaviors} />
+        )}
+        {activeTab === "conflicts" && (
+          <ConflictsPanel
+            conflicts={conflicts}
+            onDismiss={onDismissConflict}
+            onSynthesize={onSynthesize}
+          />
+        )}
+        {activeTab === "agents" && <AgentsPanel agents={dynamicAgents} />}
+        {activeTab === "trace" && <TracePanel />}
+      </div>
+    </div>
+  );
+}
+
 // ── Main App ──────────────────────────────────────────────────────────────────
 
 function App() {
@@ -404,6 +910,15 @@ function App() {
   const [systemPrompt, setSystemPrompt] = useState("");
   const [connected, setConnected] = useState(false);
 
+  // Sidebar state
+  const [sidebarOpen, setSidebarOpen] = useState(() => {
+    return localStorage.getItem("sidebarOpen") === "true";
+  });
+  const [availablePanels, setAvailablePanels] = useState<PanelId[]>([]);
+  const [conflicts, setConflicts] = useState<ConflictRecord[]>([]);
+  const [coreBehaviors, setCoreBehaviors] = useState<BehaviorRecord[]>([]);
+  const [contextualBehaviors, setContextualBehaviors] = useState<ContextualBehaviorRecord[]>([]);
+
   const wsRef = useRef<WebSocket | null>(null);
   const messagesEndRef = useRef<HTMLDivElement>(null);
 
@@ -411,7 +926,6 @@ function App() {
     messagesEndRef.current?.scrollIntoView({ behavior: "smooth" });
   }, []);
 
-  // Update a single message in state
   const upsertMessage = useCallback((msg: ChatMessage) => {
     setMessages((prev) => {
       const idx = prev.findIndex((m) => m.id === msg.id);
@@ -422,13 +936,41 @@ function App() {
     });
   }, []);
 
+  // Persist sidebar state
+  useEffect(() => {
+    localStorage.setItem("sidebarOpen", sidebarOpen ? "true" : "false");
+  }, [sidebarOpen]);
+
+  // Fetch capabilities on connect
+  const fetchCapabilities = useCallback(async () => {
+    try {
+      const res = await fetch("/api/capabilities");
+      const data = await res.json() as { panels: PanelId[] };
+      setAvailablePanels(data.panels);
+    } catch {
+      // non-critical
+    }
+  }, []);
+
+  // Fetch existing conflicts on connect
+  const fetchConflicts = useCallback(async () => {
+    try {
+      const res = await fetch("/api/behaviors/conflicts");
+      if (res.ok) {
+        const data = await res.json() as ConflictRecord[];
+        setConflicts(data);
+      }
+    } catch {
+      // non-critical
+    }
+  }, []);
+
   // WebSocket connection
   useEffect(() => {
     const protocol = location.protocol === "https:" ? "wss:" : "ws:";
     const ws = new WebSocket(`${protocol}//${location.host}/ws`);
     wsRef.current = ws;
 
-    ws.onopen = () => setConnected(true);
     ws.onclose = () => setConnected(false);
 
     ws.onmessage = (ev) => {
@@ -471,19 +1013,40 @@ function App() {
           setSystemPrompt(msg.systemPrompt);
           setCurrentModel(msg.model);
           break;
+        case "behavior_conflict":
+          setConflicts(prev => {
+            const key = [msg.newId, msg.conflictId].sort().join("::");
+            const exists = prev.some(c =>
+              [c.newId, c.conflictId].sort().join("::") === key
+            );
+            if (exists) return prev;
+            return [...prev, {
+              newId: msg.newId,
+              newText: msg.newText,
+              conflictId: msg.conflictId,
+              conflictText: msg.conflictText,
+              score: msg.score,
+              timestamp: Date.now(),
+            }];
+          });
+          break;
+        case "behaviors_loaded":
+          setCoreBehaviors(msg.core);
+          setContextualBehaviors(msg.contextual);
+          break;
       }
     };
 
-    // Request system prompt on connect
     ws.onopen = () => {
       setConnected(true);
       ws.send(JSON.stringify({ type: "system_prompt_request" }));
+      fetchCapabilities();
+      fetchConflicts();
     };
 
     return () => ws.close();
-  }, [upsertMessage]);
+  }, [upsertMessage, fetchCapabilities, fetchConflicts]);
 
-  // Auto-scroll when messages change
   useEffect(() => {
     scrollToBottom();
   }, [messages, scrollToBottom]);
@@ -605,8 +1168,6 @@ function App() {
     [messages, currentModel, systemPrompt, sendToWs],
   );
 
-  // ── Submit ───────────────────────────────────────────────────────────────────
-
   const handleSubmit = useCallback(
     (text: string) => {
       if (!handleSlash(text)) {
@@ -616,8 +1177,6 @@ function App() {
     [handleSlash, sendToWs],
   );
 
-  // ── Permission response ──────────────────────────────────────────────────────
-
   const handlePermission = useCallback(
     (response: "yes" | "always" | "no") => {
       setPendingPermission(null);
@@ -626,51 +1185,94 @@ function App() {
     [sendToWs],
   );
 
+  const handleDismissConflict = useCallback((c: ConflictRecord) => {
+    setConflicts(prev =>
+      prev.filter(x => !(x.newId === c.newId && x.conflictId === c.conflictId))
+    );
+  }, []);
+
+  const handleSynthesize = useCallback(async (c: ConflictRecord) => {
+    // Remove conflict after synthesis completes
+    setConflicts(prev =>
+      prev.filter(x => !(x.newId === c.newId && x.conflictId === c.conflictId))
+    );
+  }, []);
+
   const isBlocked = state === "thinking" || !!pendingPermission;
+  const showSidebar = sidebarOpen && availablePanels.length > 0;
 
   return (
-    <div className="app">
-      <header className="header">
-        <span className="header-title">2b</span>
-        <span className="header-model">
-          {connected ? currentModel || "connected" : "connecting…"}
-        </span>
-      </header>
+    <div className={`app-shell ${showSidebar ? "app-shell--sidebar-open" : ""}`}>
+      {/* Chat column */}
+      <div className="app">
+        <header className="header">
+          <span className="header-title">2b</span>
+          <div className="header-right">
+            <span className="header-model">
+              {connected ? currentModel || "connected" : "connecting…"}
+            </span>
+            {availablePanels.length > 0 && (
+              <button
+                className="sidebar-toggle"
+                onClick={() => setSidebarOpen(v => !v)}
+                title={sidebarOpen ? "Close panel" : "Open panel"}
+              >
+                {sidebarOpen ? "⊠" : "⊞"}
+                {!sidebarOpen && conflicts.length > 0 && (
+                  <span className="tab-badge">{conflicts.length}</span>
+                )}
+              </button>
+            )}
+          </div>
+        </header>
 
-      <div className="messages">
-        {messages.map((msg) => (
-          <MessageItem
-            key={msg.id}
-            message={msg}
-            showReasoning={showReasoning}
-          />
-        ))}
-        <div ref={messagesEndRef} />
+        <div className="messages">
+          {messages.map((msg) => (
+            <MessageItem
+              key={msg.id}
+              message={msg}
+              showReasoning={showReasoning}
+            />
+          ))}
+          <div ref={messagesEndRef} />
+        </div>
+
+        <StatusArea
+          state={state}
+          activeTools={activeTools}
+          dynamicAgents={dynamicAgents}
+        />
+
+        {state === "thinking" && (
+          <div className="stop-area">
+            <button
+              className="stop-btn"
+              onClick={() => sendToWs({ type: "interrupt", scope: "all" })}
+            >
+              ■ Stop
+            </button>
+          </div>
+        )}
+
+        <ChatInput
+          isBlocked={isBlocked}
+          agentState={state}
+          onSubmit={handleSubmit}
+        />
       </div>
 
-      <StatusArea
-        state={state}
-        activeTools={activeTools}
-        dynamicAgents={dynamicAgents}
-        model=""
-      />
-
-      {state === "thinking" && (
-        <div className="stop-area">
-          <button
-            className="stop-btn"
-            onClick={() => sendToWs({ type: "interrupt", scope: "all" })}
-          >
-            ■ Stop
-          </button>
-        </div>
+      {/* Sidebar */}
+      {showSidebar && (
+        <Sidebar
+          panels={availablePanels}
+          conflicts={conflicts}
+          coreBehaviors={coreBehaviors}
+          contextualBehaviors={contextualBehaviors}
+          dynamicAgents={dynamicAgents}
+          onDismissConflict={handleDismissConflict}
+          onSynthesize={handleSynthesize}
+        />
       )}
-
-      <ChatInput
-        isBlocked={isBlocked}
-        agentState={state}
-        onSubmit={handleSubmit}
-      />
 
       {pendingPermission && (
         <PermissionDialog

--- a/src/ui/web/WebApp.tsx
+++ b/src/ui/web/WebApp.tsx
@@ -634,7 +634,7 @@ function ConflictsPanel({
   onSynthesize,
 }: {
   conflicts: ConflictRecord[];
-  onDismiss: (c: ConflictRecord) => void;
+  onDismiss: (c: ConflictRecord) => Promise<void>;
   onSynthesize: (c: ConflictRecord) => Promise<void>;
 }) {
   const [synthesizing, setSynthesizing] = useState<string | null>(null);
@@ -841,7 +841,7 @@ function Sidebar({
   coreBehaviors: BehaviorRecord[];
   contextualBehaviors: ContextualBehaviorRecord[];
   dynamicAgents: DynamicAgentRecord[];
-  onDismissConflict: (c: ConflictRecord) => void;
+  onDismissConflict: (c: ConflictRecord) => Promise<void>;
   onSynthesize: (c: ConflictRecord) => Promise<void>;
 }) {
   const [activeTab, setActiveTab] = useState<PanelId>(panels[0] ?? "memory");
@@ -1185,7 +1185,9 @@ function App() {
     [sendToWs],
   );
 
-  const handleDismissConflict = useCallback((c: ConflictRecord) => {
+  const handleDismissConflict = useCallback(async (c: ConflictRecord) => {
+    const key = [c.newId, c.conflictId].sort().join("::");
+    await fetch(`/api/behaviors/conflicts/${encodeURIComponent(key)}`, { method: "DELETE" });
     setConflicts(prev =>
       prev.filter(x => !(x.newId === c.newId && x.conflictId === c.conflictId))
     );

--- a/src/ui/web/server.ts
+++ b/src/ui/web/server.ts
@@ -23,6 +23,18 @@
  *   { type: "permission_request", ...request }   — via WebPermissionManager transport
  *   { type: "model_changed",     model }
  *   { type: "system_prompt",     systemPrompt, model }
+ *   { type: "behavior_conflict", newId, newText, conflictId, conflictText, score }
+ *   { type: "behaviors_loaded",  core, contextual }
+ *
+ * REST API:
+ *   GET  /api/capabilities           → { panels: string[] }
+ *   GET  /api/memories               → ?type=&limit=&search=
+ *   PATCH /api/memories/:id          → { content: string }
+ *   DELETE /api/memories/:id
+ *   GET  /api/behaviors/conflicts    → ConflictRecord[]
+ *   POST /api/behaviors/synthesize   → { id_a, id_b }
+ *   GET  /api/agents                 → DynamicAgentRecord[]
+ *   GET  /api/trace/last             → RetrievalTrace | null
  *
  * The `lastPermissionToolName` module-level variable is a workaround: the
  * WebPermissionManager resolves approvals asynchronously, so the "always"
@@ -33,6 +45,8 @@
  */
 import type { ServerWebSocket } from "bun";
 import type { CortexAgent } from "../../core/CortexAgent.ts";
+import type { CortexMemoryPlugin } from "../../plugins/CortexMemoryPlugin.ts";
+import type { BehaviorPlugin } from "../../plugins/BehaviorPlugin.ts";
 import { ChatSession } from "../ChatSession.ts";
 import type { WebPermissionManager } from "./WebPermissionManager.ts";
 import index from "./index.html";
@@ -44,6 +58,19 @@ interface StartWebUIOptions {
   permissionManager: WebPermissionManager;
   onModelChange: (newModel: string) => void;
   port?: number;
+  memoryPlugin?: CortexMemoryPlugin;
+  behaviorPlugin?: BehaviorPlugin;
+}
+
+function json(data: unknown, status = 200): Response {
+  return new Response(JSON.stringify(data), {
+    status,
+    headers: { "Content-Type": "application/json" },
+  });
+}
+
+function jsonError(message: string, status = 400): Response {
+  return json({ error: message }, status);
 }
 
 // Tracks the last toolName from a permission_request so "always" can cache it.
@@ -56,6 +83,8 @@ export async function startWebUI({
   permissionManager,
   onModelChange,
   port = 3000,
+  memoryPlugin,
+  behaviorPlugin,
 }: StartWebUIOptions): Promise<void> {
   await agent.start();
 
@@ -96,12 +125,21 @@ export async function startWebUI({
     const onStateChange = (state: unknown) => send({ type: "state_change", state });
     const onActiveToolsChanged = (tools: unknown) => send({ type: "active_tools_changed", tools });
     const onDynamicAgentsChanged = (agents: unknown) => send({ type: "dynamic_agents_changed", agents });
+    const onBehaviorConflict = (
+      newId: string, newText: string, conflictId: string, conflictText: string, score: number,
+    ) => send({ type: "behavior_conflict", newId, newText, conflictId, conflictText, score });
+    const onBehaviorsLoaded = (
+      core: Array<{ id: string; text: string; weight: number }>,
+      contextual: Array<{ id: string; text: string; score: number; weight: number }>,
+    ) => send({ type: "behaviors_loaded", core, contextual });
 
     session.on("message", onMessage);
     session.on("message_updated", onMessageUpdated);
     session.on("state_change", onStateChange);
     session.on("active_tools_changed", onActiveToolsChanged);
     session.on("dynamic_agents_changed", onDynamicAgentsChanged);
+    agent.on("behavior:conflict_detected", onBehaviorConflict);
+    agent.on("behaviors_loaded", onBehaviorsLoaded);
 
     unbindSession = () => {
       session.off("message", onMessage);
@@ -109,14 +147,113 @@ export async function startWebUI({
       session.off("state_change", onStateChange);
       session.off("active_tools_changed", onActiveToolsChanged);
       session.off("dynamic_agents_changed", onDynamicAgentsChanged);
+      agent.off("behavior:conflict_detected", onBehaviorConflict);
+      agent.off("behaviors_loaded", onBehaviorsLoaded);
       unbindSession = null;
     };
+  }
+
+  // ── REST route handlers ───────────────────────────────────────────────────
+
+  function handleCapabilities(): Response {
+    const panels: string[] = [];
+    if (memoryPlugin) panels.push("memory");
+    if (behaviorPlugin) {
+      panels.push("behaviors");
+      panels.push("conflicts");
+    }
+    panels.push("agents"); // always available via session
+    if (memoryPlugin) panels.push("trace");
+    return json({ panels });
+  }
+
+  function handleGetMemories(req: Request): Response {
+    if (!memoryPlugin) return jsonError("Memory plugin not available", 503);
+    const url = new URL(req.url);
+    const type = url.searchParams.get("type") ?? undefined;
+    const limit = Math.min(200, parseInt(url.searchParams.get("limit") ?? "50", 10));
+    const search = url.searchParams.get("search") ?? undefined;
+
+    const filter: Record<string, unknown> = { limit };
+    if (type && type !== "all") filter.types = [type];
+    if (search) filter.contains = search;
+
+    const rows = memoryPlugin.queryMemoriesRaw(filter as any);
+    return json(rows);
+  }
+
+  async function handlePatchMemory(req: Request, id: string): Promise<Response> {
+    if (!memoryPlugin) return jsonError("Memory plugin not available", 503);
+    let body: { content?: string };
+    try {
+      body = await req.json() as { content?: string };
+    } catch {
+      return jsonError("Invalid JSON body");
+    }
+    if (!body.content?.trim()) return jsonError("content is required");
+    const existing = await memoryPlugin.getMemoryById(id);
+    if (!existing) return jsonError("Memory not found", 404);
+    await memoryPlugin.editMemory(id, body.content.trim());
+    return json({ ok: true });
+  }
+
+  async function handleDeleteMemory(id: string): Promise<Response> {
+    if (!memoryPlugin) return jsonError("Memory plugin not available", 503);
+    const existing = await memoryPlugin.getMemoryById(id);
+    if (!existing) return jsonError("Memory not found", 404);
+    await memoryPlugin.deleteMemoryById(id);
+    return json({ ok: true });
+  }
+
+  function handleGetConflicts(): Response {
+    if (!behaviorPlugin) return jsonError("Behavior plugin not available", 503);
+    return json(behaviorPlugin.getConflicts());
+  }
+
+  async function handleSynthesize(req: Request): Promise<Response> {
+    if (!behaviorPlugin) return jsonError("Behavior plugin not available", 503);
+    let body: { id_a?: string; id_b?: string };
+    try {
+      body = await req.json() as { id_a?: string; id_b?: string };
+    } catch {
+      return jsonError("Invalid JSON body");
+    }
+    if (!body.id_a || !body.id_b) return jsonError("id_a and id_b are required");
+    const result = await behaviorPlugin.synthesize(body.id_a, body.id_b);
+    return json({ result });
+  }
+
+  function handleGetAgents(): Response {
+    return json(session.dynamicAgents);
+  }
+
+  function handleGetTrace(): Response {
+    if (!memoryPlugin) return jsonError("Memory plugin not available", 503);
+    return json(memoryPlugin.lastRetrievalTrace);
   }
 
   Bun.serve({
     port,
     routes: {
       "/": index,
+      "/api/capabilities": { GET: handleCapabilities },
+      "/api/memories": {
+        GET: handleGetMemories,
+      },
+      "/api/memories/:id": {
+        PATCH: (req: Request) => {
+          const id = new URL(req.url).pathname.split("/").at(-1) ?? "";
+          return handlePatchMemory(req, id);
+        },
+        DELETE: (req: Request) => {
+          const id = new URL(req.url).pathname.split("/").at(-1) ?? "";
+          return handleDeleteMemory(id);
+        },
+      },
+      "/api/behaviors/conflicts": { GET: handleGetConflicts },
+      "/api/behaviors/synthesize": { POST: handleSynthesize },
+      "/api/agents": { GET: handleGetAgents },
+      "/api/trace/last": { GET: handleGetTrace },
     },
     websocket: {
       open(ws) {

--- a/src/ui/web/server.ts
+++ b/src/ui/web/server.ts
@@ -32,6 +32,7 @@
  *   PATCH /api/memories/:id          → { content: string }
  *   DELETE /api/memories/:id
  *   GET  /api/behaviors/conflicts    → ConflictRecord[]
+ *   DELETE /api/behaviors/conflicts/:key
  *   POST /api/behaviors/synthesize   → { id_a, id_b }
  *   GET  /api/agents                 → DynamicAgentRecord[]
  *   GET  /api/trace/last             → RetrievalTrace | null
@@ -47,6 +48,7 @@ import type { ServerWebSocket } from "bun";
 import type { CortexAgent } from "../../core/CortexAgent.ts";
 import type { CortexMemoryPlugin } from "../../plugins/CortexMemoryPlugin.ts";
 import type { BehaviorPlugin } from "../../plugins/BehaviorPlugin.ts";
+import type { MemoryFilter } from "../../plugins/CortexMemoryDatabase.ts";
 import { ChatSession } from "../ChatSession.ts";
 import type { WebPermissionManager } from "./WebPermissionManager.ts";
 import index from "./index.html";
@@ -174,11 +176,11 @@ export async function startWebUI({
     const limit = Math.min(200, parseInt(url.searchParams.get("limit") ?? "50", 10));
     const search = url.searchParams.get("search") ?? undefined;
 
-    const filter: Record<string, unknown> = { limit };
+    const filter: MemoryFilter = { limit };
     if (type && type !== "all") filter.types = [type];
     if (search) filter.contains = search;
 
-    const rows = memoryPlugin.queryMemoriesRaw(filter as any);
+    const rows = memoryPlugin.queryMemoriesRaw(filter);
     return json(rows);
   }
 
@@ -208,6 +210,14 @@ export async function startWebUI({
   function handleGetConflicts(): Response {
     if (!behaviorPlugin) return jsonError("Behavior plugin not available", 503);
     return json(behaviorPlugin.getConflicts());
+  }
+
+  function handleDismissConflict(req: Request): Response {
+    if (!behaviorPlugin) return jsonError("Behavior plugin not available", 503);
+    const key = decodeURIComponent(new URL(req.url).pathname.split("/").at(-1) ?? "");
+    if (!key) return jsonError("Conflict key required");
+    behaviorPlugin.dismissConflict(key);
+    return json({ ok: true });
   }
 
   async function handleSynthesize(req: Request): Promise<Response> {
@@ -251,6 +261,7 @@ export async function startWebUI({
         },
       },
       "/api/behaviors/conflicts": { GET: handleGetConflicts },
+      "/api/behaviors/conflicts/:key": { DELETE: handleDismissConflict },
       "/api/behaviors/synthesize": { POST: handleSynthesize },
       "/api/agents": { GET: handleGetAgents },
       "/api/trace/last": { GET: handleGetTrace },

--- a/src/ui/web/styles.css
+++ b/src/ui/web/styles.css
@@ -765,6 +765,536 @@ body {
   font-style: italic;
 }
 
+/* ── App shell (two-column layout) ── */
+
+.app-shell {
+  display: flex;
+  height: 100%;
+  overflow: hidden;
+}
+
+.app-shell--sidebar-open .app {
+  max-width: none;
+  margin: 0;
+  flex: 1;
+  min-width: 0;
+}
+
+/* ── Header right ── */
+
+.header-right {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.sidebar-toggle {
+  background: none;
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-dim);
+  font-family: inherit;
+  font-size: 14px;
+  padding: 2px 7px;
+  cursor: pointer;
+  transition: color 0.15s, border-color 0.15s;
+  position: relative;
+}
+
+.sidebar-toggle:hover {
+  color: var(--cyan);
+  border-color: var(--cyan);
+}
+
+/* ── Sidebar ── */
+
+.sidebar {
+  width: 380px;
+  flex-shrink: 0;
+  display: flex;
+  flex-direction: column;
+  border-left: 1px solid var(--border);
+  background: var(--surface);
+  overflow: hidden;
+}
+
+.sidebar-tabs {
+  display: flex;
+  flex-shrink: 0;
+  border-bottom: 1px solid var(--border);
+  background: var(--bg);
+  overflow-x: auto;
+}
+
+.sidebar-tab {
+  flex-shrink: 0;
+  background: none;
+  border: none;
+  border-bottom: 2px solid transparent;
+  color: var(--text-dim);
+  font-family: inherit;
+  font-size: 12px;
+  padding: 7px 12px;
+  cursor: pointer;
+  white-space: nowrap;
+  position: relative;
+  transition: color 0.1s, border-color 0.1s;
+}
+
+.sidebar-tab:hover {
+  color: var(--text);
+}
+
+.sidebar-tab--active {
+  color: var(--cyan);
+  border-bottom-color: var(--cyan);
+}
+
+.sidebar-content {
+  flex: 1;
+  overflow-y: auto;
+  overflow-x: hidden;
+}
+
+.sidebar-content::-webkit-scrollbar {
+  width: 4px;
+}
+.sidebar-content::-webkit-scrollbar-track {
+  background: transparent;
+}
+.sidebar-content::-webkit-scrollbar-thumb {
+  background: var(--border);
+  border-radius: 2px;
+}
+
+/* ── Tab badge ── */
+
+.tab-badge {
+  display: inline-flex;
+  align-items: center;
+  justify-content: center;
+  min-width: 16px;
+  height: 16px;
+  background: var(--red);
+  color: #fff;
+  font-size: 10px;
+  font-weight: bold;
+  border-radius: 8px;
+  padding: 0 4px;
+  margin-left: 4px;
+  line-height: 1;
+}
+
+/* ── Panel base ── */
+
+.panel {
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.panel-controls {
+  display: flex;
+  gap: 6px;
+  flex-wrap: wrap;
+  align-items: center;
+}
+
+.panel-list {
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+}
+
+.panel-loading,
+.panel-empty {
+  font-size: 12px;
+  color: var(--text-dim);
+  padding: 8px 4px;
+  text-align: center;
+}
+
+.panel-section-label {
+  font-size: 11px;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.06em;
+  color: var(--text-dim);
+  padding: 4px 2px 2px;
+  margin-top: 4px;
+}
+
+.panel-select {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text);
+  font-family: inherit;
+  font-size: 12px;
+  padding: 4px 6px;
+  outline: none;
+  cursor: pointer;
+}
+
+.panel-select:focus {
+  border-color: var(--cyan);
+}
+
+.panel-input {
+  flex: 1;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text);
+  font-family: inherit;
+  font-size: 12px;
+  padding: 4px 6px;
+  outline: none;
+  min-width: 0;
+}
+
+.panel-input::placeholder {
+  color: var(--text-dim);
+}
+
+.panel-input:focus {
+  border-color: var(--cyan);
+}
+
+.panel-btn {
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text-dim);
+  font-family: inherit;
+  font-size: 12px;
+  padding: 4px 9px;
+  cursor: pointer;
+  white-space: nowrap;
+  transition: color 0.1s, border-color 0.1s;
+}
+
+.panel-btn:hover:not(:disabled) {
+  color: var(--text);
+  border-color: var(--gray);
+}
+
+.panel-btn:disabled {
+  opacity: 0.4;
+  cursor: not-allowed;
+}
+
+.panel-btn--green {
+  color: var(--green);
+  border-color: var(--green);
+}
+
+.panel-btn--green:hover:not(:disabled) {
+  background: rgba(74, 222, 128, 0.08);
+  color: var(--green);
+  border-color: var(--green);
+}
+
+.panel-btn--red {
+  color: var(--red);
+  border-color: var(--red);
+}
+
+.panel-btn--red:hover:not(:disabled) {
+  background: rgba(248, 113, 113, 0.08);
+  color: var(--red);
+  border-color: var(--red);
+}
+
+/* ── Memory panel ── */
+
+.memory-item {
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  overflow: hidden;
+}
+
+.memory-header {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+  padding: 5px 8px;
+  cursor: pointer;
+  background: var(--bg);
+  font-size: 12px;
+  user-select: none;
+  transition: background 0.1s;
+}
+
+.memory-header:hover {
+  background: var(--border);
+}
+
+.memory-type {
+  font-size: 11px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+  flex-shrink: 0;
+}
+
+.memory-id {
+  color: var(--text-dim);
+  font-size: 11px;
+  flex-shrink: 0;
+}
+
+.memory-date {
+  color: var(--text-dim);
+  font-size: 11px;
+  margin-left: auto;
+  flex-shrink: 0;
+}
+
+.memory-weight {
+  font-size: 11px;
+  padding: 1px 5px;
+  border-radius: 3px;
+  border: 1px solid var(--yellow);
+  color: var(--yellow);
+  flex-shrink: 0;
+}
+
+.memory-body {
+  padding: 8px;
+  border-top: 1px solid var(--border);
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+  font-size: 12px;
+}
+
+.memory-text {
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--text);
+  line-height: 1.5;
+}
+
+.memory-tags {
+  display: flex;
+  flex-wrap: wrap;
+  gap: 4px;
+}
+
+.tag {
+  font-size: 11px;
+  padding: 1px 6px;
+  border-radius: 3px;
+  background: rgba(34, 211, 238, 0.1);
+  border: 1px solid rgba(34, 211, 238, 0.3);
+  color: var(--cyan);
+}
+
+.memory-edit-area {
+  width: 100%;
+  background: var(--bg);
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  color: var(--text);
+  font-family: inherit;
+  font-size: 12px;
+  padding: 6px;
+  resize: vertical;
+  outline: none;
+  line-height: 1.5;
+}
+
+.memory-edit-area:focus {
+  border-color: var(--cyan);
+}
+
+.memory-actions {
+  display: flex;
+  gap: 6px;
+}
+
+/* ── Behavior panel ── */
+
+.behavior-item {
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  padding: 6px 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+}
+
+.behavior-item--core {
+  border-color: rgba(34, 211, 238, 0.3);
+  background: rgba(34, 211, 238, 0.04);
+}
+
+.behavior-meta {
+  display: flex;
+  align-items: center;
+  gap: 6px;
+}
+
+.behavior-text {
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--text);
+  line-height: 1.5;
+}
+
+.behavior-score {
+  font-size: 11px;
+  color: var(--text-dim);
+}
+
+/* ── Conflict panel ── */
+
+.conflict-item {
+  border: 1px solid rgba(248, 113, 113, 0.3);
+  border-radius: 5px;
+  padding: 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 8px;
+  font-size: 12px;
+}
+
+.conflict-score {
+  font-size: 11px;
+  color: var(--red);
+  font-weight: bold;
+}
+
+.conflict-pair {
+  display: flex;
+  flex-direction: column;
+  gap: 6px;
+}
+
+.conflict-behavior {
+  border: 1px solid var(--border);
+  border-radius: 4px;
+  padding: 6px;
+  display: flex;
+  flex-direction: column;
+  gap: 3px;
+}
+
+.conflict-label {
+  font-size: 11px;
+  font-weight: bold;
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  color: var(--text-dim);
+}
+
+.conflict-text {
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--text);
+  line-height: 1.5;
+}
+
+.conflict-result {
+  background: rgba(74, 222, 128, 0.06);
+  border: 1px solid rgba(74, 222, 128, 0.3);
+  border-radius: 4px;
+  padding: 6px;
+  white-space: pre-wrap;
+  word-break: break-word;
+  color: var(--green);
+  font-size: 12px;
+  line-height: 1.5;
+}
+
+.conflict-actions {
+  display: flex;
+  gap: 6px;
+}
+
+/* ── Agents panel ── */
+
+.agent-item {
+  border: 1px solid var(--border);
+  border-radius: 5px;
+  padding: 6px 8px;
+  display: flex;
+  flex-direction: column;
+  gap: 4px;
+  font-size: 12px;
+}
+
+.agent-header {
+  display: flex;
+  align-items: center;
+  justify-content: space-between;
+  gap: 6px;
+}
+
+.agent-name {
+  font-weight: bold;
+  color: var(--magenta);
+}
+
+.agent-state {
+  font-size: 11px;
+  padding: 1px 6px;
+  border-radius: 3px;
+  border: 1px solid var(--border);
+  color: var(--text-dim);
+}
+
+.agent-state--thinking {
+  border-color: var(--yellow);
+  color: var(--yellow);
+}
+
+.agent-state--error {
+  border-color: var(--red);
+  color: var(--red);
+}
+
+.agent-state--idle {
+  color: var(--text-dim);
+  border-color: var(--border);
+}
+
+.agent-meta {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+}
+
+.agent-type {
+  color: var(--text-dim);
+  font-size: 11px;
+}
+
+.agent-date {
+  color: var(--text-dim);
+  font-size: 11px;
+  margin-left: auto;
+}
+
+/* ── Trace panel ── */
+
+.trace-item {
+  display: flex;
+  align-items: center;
+  gap: 8px;
+  padding: 3px 4px;
+  font-size: 12px;
+  border-bottom: 1px solid var(--border);
+}
+
+.trace-item:last-child {
+  border-bottom: none;
+}
+
 /* ── Slash command suggestions (future) ── */
 
 /* ── Responsive ── */


### PR DESCRIPTION
Extracts self-shaping behavior into a dedicated opt-in BehaviorPlugin, replacing the binary core/contextual split with a 0.0–1.0 weight field, and expands the web UI from a chat interface into a management dashboard with collapsible sidebar panels for memory, behaviors, conflicts, agents, and retrieval traces.

Key changes:
- BehaviorPlugin: owns save_behavior, synthesize_behaviors, activate_profile, force_behavior, suppress_behavior; weight-based injection (>=0.9 always active, <0.9 semantic with weight-adjusted threshold); conflict detection at 0.5–0.85 similarity range with agent event emission
- CortexMemoryDatabase: additive schema migration adding weight column (default 1.0); updated queries to include weight in results
- CortexMemoryPlugin: removed behavior injection and save_behavior tool (now owned by BehaviorPlugin); added getOrComputeEmbedding(), searchBehaviorsWithEmbedding(), supersedeBehavior(), editMemory() public APIs for BehaviorPlugin and REST endpoints
- server.ts: REST API (capabilities, memories CRUD, conflicts, synthesize, agents, trace); behavior_conflict and behaviors_loaded WebSocket events forwarded to client
- WebApp.tsx: sidebar panel system with Memory browser, Active Behaviors, Conflicts (with synthesis), Agents, and Turn Trace panels; capabilities-driven tab visibility; localStorage sidebar persistence
- styles.css: full sidebar and panel styles