### PR TITLE
Resolve audit findings F-3, F-22, F-25, F-27

### DIFF
--- a/packages/app-2b/src/ui/ChatSession.ts
+++ b/packages/app-2b/src/ui/ChatSession.ts
@@ -34,9 +34,9 @@ import type {
  */
 export type AgentLike = {
   addDirect(text: string): void;
-  interrupt(): void;
+  interrupt(): Promise<void>;
   interruptSubAgents(): void;
-  interruptAll(): void;
+  interruptAll(): Promise<void>;
   setTokenCallback(fn: (token: string, isReasoning: boolean) => void): void;
 } & {
   on<K extends keyof AgentEventMap>(event: K, listener: (...args: AgentEventMap[K]) => void): AgentLike;

--- a/packages/framework/src/core/BaseAgent.test.ts
+++ b/packages/framework/src/core/BaseAgent.test.ts
@@ -1147,3 +1147,261 @@ describe("BaseAgent - F-13: veto runs before permission prompt", () => {
     agent.stop();
   });
 });
+
+describe("BaseAgent - F-22: setSystemPrompt() replaces prompt at runtime", () => {
+  test("setSystemPrompt swaps the prompt used on the next tick", async () => {
+    const llm = makeLLM("ok");
+    const agent = new BaseAgent(llm, makeConfig({ systemPrompt: "ORIGINAL_PROMPT" }));
+
+    agent.setSystemPrompt("REPLACEMENT_PROMPT");
+    agent.addDirect("hi");
+    await waitForIdle(agent);
+
+    const systemPrompt: string = (llm.chat as ReturnType<typeof mock>).mock.calls[0]![1];
+    expect(systemPrompt).toContain("REPLACEMENT_PROMPT");
+    expect(systemPrompt).not.toContain("ORIGINAL_PROMPT");
+    agent.stop();
+  });
+
+  test("setSystemPrompt emits system_prompt_updated with the new value", async () => {
+    const agent = new BaseAgent(makeLLM(), makeConfig({ systemPrompt: "OLD" }));
+
+    const fired: string[] = [];
+    agent.on("system_prompt_updated", (p) => fired.push(p));
+
+    agent.setSystemPrompt("NEW");
+    expect(fired).toEqual(["NEW"]);
+    agent.stop();
+  });
+});
+
+describe("BaseAgent - F-27: interrupt() returns Promise resolving on idle", () => {
+  test("interrupt() while thinking resolves only after state_change('idle')", async () => {
+    // LLM intentionally ignores the abort signal — it only resolves when we
+    // release the gate. This isolates the test to the interrupt-vs-idle race
+    // and removes any dependency on provider-side abort responsiveness.
+    let releaseLLM!: () => void;
+    const llmGate = new Promise<void>((resolve) => { releaseLLM = resolve; });
+    const llm: LLMProvider = {
+      chat: mock(async () => {
+        await llmGate;
+        return { response: "x", nonReasoningContent: "x", reasoningContent: "", reasoningText: "" };
+      }),
+      embed: mock(async () => []),
+    } as unknown as LLMProvider;
+
+    const agent = new BaseAgent(llm, makeConfig());
+    agent.on("error", () => {});
+
+    agent.addDirect("hi");
+    await new Promise((r) => setTimeout(r, 5)); // let act() reach the LLM call
+
+    let resolved = false;
+    const interruptPromise = agent.interrupt().then(() => { resolved = true; });
+
+    // interrupt() must NOT have resolved synchronously; the agent is still
+    // mid-LLM-call and hasn't emitted state_change("idle") yet.
+    await new Promise((r) => setTimeout(r, 20));
+    expect(resolved).toBe(false);
+
+    releaseLLM();
+    await interruptPromise;
+    expect(resolved).toBe(true);
+    agent.stop();
+  });
+
+  test("interrupt() when idle resolves immediately", async () => {
+    const agent = new BaseAgent(makeLLM("ok"), makeConfig());
+    // Never sent any input — agent is idle and has no AbortController.
+    const t0 = performance.now();
+    await agent.interrupt();
+    const elapsed = performance.now() - t0;
+    expect(elapsed).toBeLessThan(50);
+    agent.stop();
+  });
+
+  test("interrupt() return value can be safely ignored (fire-and-forget)", async () => {
+    const agent = new BaseAgent(makeLLM("ok"), makeConfig());
+
+    // Discard the returned promise — should not produce an unhandled rejection
+    // and should not throw.
+    expect(() => { agent.interrupt(); }).not.toThrow();
+    // Wait a beat to ensure no rejection surfaces.
+    await new Promise((r) => setTimeout(r, 10));
+    agent.stop();
+  });
+});
+
+describe("BaseAgent - F-3: queued event when tick re-enters mid-turn", () => {
+  test("addDirect while a tick is in flight emits queued with the new direct depth", async () => {
+    // LLM that blocks until we explicitly release it, simulating a slow turn.
+    let releaseLLM!: () => void;
+    const llmGate = new Promise<void>((resolve) => { releaseLLM = resolve; });
+    const llm: LLMProvider = {
+      chat: mock(async () => {
+        await llmGate;
+        return { response: "ok", nonReasoningContent: "ok", reasoningContent: "", reasoningText: "" };
+      }),
+      embed: mock(async () => []),
+    } as unknown as LLMProvider;
+
+    const agent = new BaseAgent(llm, makeConfig());
+
+    const queuedPromise = waitForEvent(agent, "queued", 500);
+    agent.addDirect("first"); // kicks off tick; LLM call blocks
+    // Yield to the event loop so act() sets isThinking=true before the next addDirect.
+    await new Promise((r) => setTimeout(r, 5));
+    agent.addDirect("second"); // re-enters tick() while isThinking=true
+
+    const [payload] = (await queuedPromise) as [{ directDepth: number; ambientDepth: number }];
+    expect(payload.directDepth).toBe(1);
+    expect(payload.ambientDepth).toBe(0);
+
+    releaseLLM();
+    await waitForIdle(agent);
+    agent.stop();
+  });
+
+  test("queued event payload reflects ambient depth too", async () => {
+    let releaseLLM!: () => void;
+    const llmGate = new Promise<void>((resolve) => { releaseLLM = resolve; });
+    const llm: LLMProvider = {
+      chat: mock(async () => {
+        await llmGate;
+        return { response: "ok", nonReasoningContent: "ok", reasoningContent: "", reasoningText: "" };
+      }),
+      embed: mock(async () => []),
+    } as unknown as LLMProvider;
+
+    const agent = new BaseAgent(llm, makeConfig());
+
+    const queuedPromise = waitForEvent(agent, "queued", 500);
+    agent.addDirect("first");
+    await new Promise((r) => setTimeout(r, 5));
+    agent.addAmbient("ambient noise", { forceTick: true });
+
+    const [payload] = (await queuedPromise) as [{ directDepth: number; ambientDepth: number }];
+    expect(payload.directDepth).toBe(0);
+    expect(payload.ambientDepth).toBe(1);
+
+    releaseLLM();
+    await waitForIdle(agent);
+    agent.stop();
+  });
+
+  test("tick() re-entry with empty queues does NOT emit queued", async () => {
+    const agent = new BaseAgent(makeLLM("ok"), makeConfig());
+
+    const events: unknown[] = [];
+    agent.on("queued", (p) => events.push(p));
+
+    // No queue contents — calling tick() directly during a run shouldn't fire.
+    agent.addDirect("only");
+    await waitForIdle(agent);
+
+    expect(events).toHaveLength(0);
+    agent.stop();
+  });
+});
+
+describe("BaseAgent - F-25: extended tick_metrics (retries/aborted/queueDepthAtStart)", () => {
+  test("retries counts every attempt past the first across all tool calls in the tick", async () => {
+    let attempts = 0;
+    const llm: LLMProvider = {
+      chat: mock(async (_msgs, _sys, _schema, tools) => {
+        const flaky = tools?.find((t) => t.name === "flaky");
+        if (flaky?.implementation) await flaky.implementation({});
+        return { response: "done", nonReasoningContent: "done", reasoningContent: "", reasoningText: "" };
+      }),
+      embed: mock(async () => []),
+    } as unknown as LLMProvider;
+
+    const plugin: AgentPlugin = {
+      name: "FlakyPlugin",
+      getTools: () => [{
+        name: "flaky",
+        description: "",
+        parameters: {},
+        permission: "none",
+        retry: { maxAttempts: 3, delayMs: 0 },
+      }],
+      executeTool: async () => {
+        attempts++;
+        if (attempts < 3) throw new Error("transient");
+        return "ok";
+      },
+    };
+    const agent = new BaseAgent(llm, makeConfig());
+    agent.registerPlugin(plugin);
+
+    const metricsPromise = waitForEvent(agent, "tick_metrics", 500);
+    agent.addDirect("go");
+    const [metrics] = (await metricsPromise) as [import("./types").TickMetrics];
+
+    // 3 attempts → 2 retries past the first
+    expect(metrics.retries).toBe(2);
+    agent.stop();
+  });
+
+  test("retries is 0 when no tool calls happen", async () => {
+    const agent = new BaseAgent(makeLLM("hello"), makeConfig());
+    const metricsPromise = waitForEvent(agent, "tick_metrics", 500);
+    agent.addDirect("hi");
+    const [metrics] = (await metricsPromise) as [import("./types").TickMetrics];
+    expect(metrics.retries).toBe(0);
+    agent.stop();
+  });
+
+  test("aborted=true when interrupt() fires before the tick finishes", async () => {
+    // LLM chat resolves after a delay — we trigger interrupt() during that window
+    // so the abort signal observed at emit-time is set.
+    const llm: LLMProvider = {
+      chat: mock(async (_msgs, _sys, _schema, _tools, _cb, signal) => {
+        await new Promise<void>((resolve, reject) => {
+          const t = setTimeout(() => resolve(), 30);
+          signal?.addEventListener("abort", () => { clearTimeout(t); reject(new Error("aborted")); }, { once: true });
+        });
+        return { response: "x", nonReasoningContent: "x", reasoningContent: "", reasoningText: "" };
+      }),
+      embed: mock(async () => []),
+    } as unknown as LLMProvider;
+
+    const agent = new BaseAgent(llm, makeConfig());
+    agent.on("error", () => {});
+    const metricsPromise = waitForEvent(agent, "tick_metrics", 500);
+    agent.addDirect("hi");
+    // Let act() reach the LLM call before interrupting
+    setTimeout(() => agent.interrupt(), 5);
+
+    const [metrics] = (await metricsPromise) as [import("./types").TickMetrics];
+    expect(metrics.aborted).toBe(true);
+    expect(metrics.errored).toBe(true);
+    agent.stop();
+  });
+
+  test("aborted=false on a normal tick where interrupt() never fires", async () => {
+    const agent = new BaseAgent(makeLLM("ok"), makeConfig());
+    const metricsPromise = waitForEvent(agent, "tick_metrics", 500);
+    agent.addDirect("hi");
+    const [metrics] = (await metricsPromise) as [import("./types").TickMetrics];
+    expect(metrics.aborted).toBe(false);
+    agent.stop();
+  });
+
+  test("queueDepthAtStart reflects direct + ambient drained at the start of act()", async () => {
+    const agent = new BaseAgent(makeLLM("ok"), makeConfig());
+
+    // Stop the heartbeat loop from firing while we stack inputs.
+    // addAmbient without forceTick will NOT trigger a tick — so we can pile up
+    // two ambient items, then trigger with addDirect (which adds a third item).
+    agent.addAmbient("ambient-1");
+    agent.addAmbient("ambient-2");
+
+    const metricsPromise = waitForEvent(agent, "tick_metrics", 500);
+    agent.addDirect("direct-1");
+    const [metrics] = (await metricsPromise) as [import("./types").TickMetrics];
+
+    expect(metrics.queueDepthAtStart).toBe(3);
+    agent.stop();
+  });
+});

--- a/packages/framework/src/core/BaseAgent.ts
+++ b/packages/framework/src/core/BaseAgent.ts
@@ -65,6 +65,12 @@ export class BaseAgent extends EventEmitter {
    * actually invoked this turn.
    */
   private currentTickToolCalls: Record<string, number> = {};
+  /**
+   * Per-tick total of retry attempts charged across all tool calls. Incremented
+   * by the buildTools wrapper each time it loops past its first attempt. Reset
+   * at the start of every act() and surfaced through TickMetrics.retries.
+   */
+  private currentTickRetries = 0;
 
   public get name(): string {
     return this.config.name ?? "Agent";
@@ -136,10 +142,27 @@ export class BaseAgent extends EventEmitter {
     this.emit("memory:write_request", request);
   }
 
-  /** Cancel the current LLM inference (e.g. for barge-in). */
-  public interrupt() {
+  /**
+   * Cancel the current LLM inference (e.g. for barge-in).
+   *
+   * Returns a Promise that resolves on the next `state_change("idle")` — i.e.
+   * once the in-flight tick has unwound. If the agent is already idle, the
+   * Promise resolves on the next microtask so the caller can `await` without
+   * deadlocking. Callers that don't `await` are unaffected (fire-and-forget).
+   */
+  public interrupt(): Promise<void> {
+    const wasThinking = this.isThinking;
     if (this.currentAbortController) this.currentAbortController.abort();
     this.emit("interrupt");
+    if (!wasThinking) return Promise.resolve();
+    return new Promise<void>((resolve) => {
+      const onIdle = (state: "idle" | "thinking") => {
+        if (state !== "idle") return;
+        this.off("state_change", onIdle);
+        resolve();
+      };
+      this.on("state_change", onIdle);
+    });
   }
 
   /** Interrupt all in-flight subagent asks without stopping the main agent. */
@@ -152,10 +175,13 @@ export class BaseAgent extends EventEmitter {
     }
   }
 
-  /** Interrupt all subagents and the main agent's current LLM call. */
-  public interruptAll(): void {
+  /**
+   * Interrupt all subagents and the main agent's current LLM call.
+   * Returns the same idle-resolving Promise as `interrupt()`.
+   */
+  public interruptAll(): Promise<void> {
     this.interruptSubAgents();
-    this.interrupt();
+    return this.interrupt();
   }
 
   /**
@@ -236,6 +262,19 @@ export class BaseAgent extends EventEmitter {
     return this.lastSystemPrompt;
   }
 
+  /**
+   * Replace the base system prompt at runtime. The new value is used starting
+   * with the next tick — in-flight ticks are unaffected. Plugin
+   * getSystemPromptFragment / getContext contributions are still appended on
+   * top, as they are on every tick.
+   *
+   * Emits `system_prompt_updated` with the value that will be used.
+   */
+  public setSystemPrompt(prompt: string): void {
+    this.config.systemPrompt = prompt;
+    this.emit("system_prompt_updated", prompt);
+  }
+
   public async start() {
     logger.info("BaseAgent", `Starting ${this.name} with ${this.plugins.length} plugins`);
     // Initialize all plugins concurrently. allSettled is used instead of all so
@@ -300,7 +339,17 @@ export class BaseAgent extends EventEmitter {
   }
 
   private async tick() {
-    if (this.isThinking) return;
+    if (this.isThinking) {
+      // The agent is already mid-turn but new input has arrived — emit so UIs
+      // can surface "your message is queued" without polling. Only fire when
+      // there is something actually waiting; an empty tick re-entry is silent.
+      const directDepth = this.directQueue.length;
+      const ambientDepth = this.ambientQueue.length;
+      if (directDepth > 0 || ambientDepth > 0) {
+        this.emit("queued", { directDepth, ambientDepth });
+      }
+      return;
+    }
     if (this.tickTimer) clearTimeout(this.tickTimer);
 
     const direct = [...this.directQueue];
@@ -490,6 +539,7 @@ export class BaseAgent extends EventEmitter {
                     ? base * 2 ** (attempt - 2)
                     : base;
                   if (wait > 0) await new Promise(r => setTimeout(r, wait));
+                  this.currentTickRetries++;
                   this.emit("log", `[Retry] ${toolName}: attempt ${attempt}/${maxAttempts}`);
                 }
                 try {
@@ -608,7 +658,9 @@ export class BaseAgent extends EventEmitter {
     let toolCount = 0;
     let ignored = false;
     let errored = false;
+    const queueDepthAtStart = direct.length + ambient.length;
     this.currentTickToolCalls = {};
+    this.currentTickRetries = 0;
 
     try {
       const collectMessagesStart = performance.now();
@@ -701,6 +753,9 @@ export class BaseAgent extends EventEmitter {
         toolsCalled: { ...this.currentTickToolCalls },
         ignored,
         errored,
+        retries: this.currentTickRetries,
+        aborted: this.currentAbortController?.signal.aborted ?? false,
+        queueDepthAtStart,
       });
     }
   }

--- a/packages/framework/src/core/CortexAgent.test.ts
+++ b/packages/framework/src/core/CortexAgent.test.ts
@@ -198,3 +198,37 @@ describe("CortexAgent - event forwarding", () => {
     agent.stop();
   });
 });
+
+describe("CortexAgent - F-22: setSystemPrompt re-augments cortex directives", () => {
+  test("setSystemPrompt replaces the base prompt but keeps the three cortex directives", async () => {
+    const llm = makeLLM("ok");
+    const agent = new CortexAgent(llm, { ...BASE_CONFIG, systemPrompt: "ORIGINAL_BASE", heartbeatInterval: 100000 });
+
+    agent.setSystemPrompt("REPLACEMENT_BASE");
+    agent.addDirect("hi");
+    await waitForIdle(agent);
+
+    const systemPrompt: string = (llm.chat as ReturnType<typeof mock>).mock.calls[0]![1];
+    expect(systemPrompt).toContain("REPLACEMENT_BASE");
+    expect(systemPrompt).not.toContain("ORIGINAL_BASE");
+    // Each of the three directives must still be present.
+    expect(systemPrompt).toContain("You have internal thoughts stored in thought memory");
+    expect(systemPrompt).toContain("You may act proactively");
+    expect(systemPrompt).toContain("Question the coherence of ideas you encounter");
+    agent.stop();
+  });
+
+  test("system_prompt_updated event fires with the augmented prompt", async () => {
+    const agent = new CortexAgent(makeLLM(), { ...BASE_CONFIG, systemPrompt: "ORIGINAL", heartbeatInterval: 100000 });
+
+    const fired: string[] = [];
+    agent.on("system_prompt_updated" as any, (p: string) => fired.push(p));
+
+    agent.setSystemPrompt("REPLACEMENT");
+
+    expect(fired).toHaveLength(1);
+    expect(fired[0]).toContain("REPLACEMENT");
+    expect(fired[0]).toContain("You have internal thoughts stored in thought memory");
+    agent.stop();
+  });
+});

--- a/packages/framework/src/core/CortexAgent.ts
+++ b/packages/framework/src/core/CortexAgent.ts
@@ -44,18 +44,7 @@ export class CortexAgent<TEvents extends AgentEventMap = AgentEventMap> {
    *                          Defaults to `llm` if omitted.
    */
   constructor(llm: LLMProvider, config: AgentConfig, synthesisProvider?: LLMProvider) {
-    // Append cortex-specific directives after the caller's system prompt so they
-    // can't accidentally be overridden and always appear in every tick.
-    const cortexSystemPrompt = [
-      config.systemPrompt,
-      "You have internal thoughts stored in thought memory. Review recent thoughts before responding.",
-      "You may act proactively — don't only respond to explicit requests.",
-      "Question the coherence of ideas you encounter. Look for contradictions.",
-    ]
-      .filter(Boolean)
-      .join("\n\n");
-
-    this.inner = new BaseAgent(llm, { ...config, systemPrompt: cortexSystemPrompt });
+    this.inner = new BaseAgent(llm, { ...config, systemPrompt: this.augmentWithCortexDirectives(config.systemPrompt) });
 
     // cortexName determines the memory namespace. Falls back to config.name then "cortex".
     // Multiple unnamed CortexAgent instances will share the "cortex" namespace — assign
@@ -70,6 +59,31 @@ export class CortexAgent<TEvents extends AgentEventMap = AgentEventMap> {
     this.inner.registerPlugin(thoughtPlugin);
     this.inner.registerPlugin(metacognitionPlugin);
     this.inner.registerPlugin(new YieldPlugin());
+  }
+
+  /**
+   * Append the three cortex directives to the caller's system prompt. Called
+   * by the constructor and re-applied on every setSystemPrompt() so the
+   * directives can't be lost when the prompt is replaced at runtime.
+   */
+  private augmentWithCortexDirectives(basePrompt: string): string {
+    return [
+      basePrompt,
+      "You have internal thoughts stored in thought memory. Review recent thoughts before responding.",
+      "You may act proactively — don't only respond to explicit requests.",
+      "Question the coherence of ideas you encounter. Look for contradictions.",
+    ]
+      .filter(Boolean)
+      .join("\n\n");
+  }
+
+  /**
+   * Replace the base system prompt at runtime, then re-append the cortex
+   * directives so they always appear in every tick. The inner BaseAgent will
+   * emit `system_prompt_updated` with the augmented value.
+   */
+  public setSystemPrompt(prompt: string): void {
+    this.inner.setSystemPrompt(this.augmentWithCortexDirectives(prompt));
   }
 
   /** Register an additional plugin with the underlying agent. */
@@ -104,9 +118,13 @@ export class CortexAgent<TEvents extends AgentEventMap = AgentEventMap> {
     this.inner.addAmbient(text, opts);
   }
 
-  /** Cancel the current LLM inference (e.g. for barge-in). */
-  public interrupt(): void {
-    this.inner.interrupt();
+  /**
+   * Cancel the current LLM inference (e.g. for barge-in).
+   * Returns a Promise that resolves on the next idle transition. Callers that
+   * don't await are unaffected — the work fires regardless.
+   */
+  public interrupt(): Promise<void> {
+    return this.inner.interrupt();
   }
 
   /** Interrupt all in-flight subagent asks without stopping the main agent. */
@@ -114,9 +132,12 @@ export class CortexAgent<TEvents extends AgentEventMap = AgentEventMap> {
     this.inner.interruptSubAgents();
   }
 
-  /** Interrupt all subagents and the main agent's current LLM call. */
-  public interruptAll(): void {
-    this.inner.interruptAll();
+  /**
+   * Interrupt all subagents and the main agent's current LLM call.
+   * Returns the same idle-resolving Promise as `interrupt()`.
+   */
+  public interruptAll(): Promise<void> {
+    return this.inner.interruptAll();
   }
 
   /**

--- a/packages/framework/src/core/TickMetricsAggregator.test.ts
+++ b/packages/framework/src/core/TickMetricsAggregator.test.ts
@@ -18,6 +18,10 @@ function tick(overrides: Partial<TickMetrics> = {}): TickMetrics {
     contextContributors: 3,
     toolsCalled: {},
     ignored: false,
+    errored: false,
+    retries: 0,
+    aborted: false,
+    queueDepthAtStart: 0,
     ...overrides,
   };
 }

--- a/packages/framework/src/core/TickMetricsAggregator.ts
+++ b/packages/framework/src/core/TickMetricsAggregator.ts
@@ -57,6 +57,10 @@ export class TickMetricsAggregator {
     let contextContributors = 0;
     let ignoredCount = 0;
     let erroredCount = 0;
+    let abortedCount = 0;
+    let retriesSum = 0;
+    let queueDepthAtStartSum = 0;
+    let queueDepthAtStartMax = 0;
 
     // sum and per-plugin sum
     const pluginTotals = new Map<string, { sum: number; count: number; max: number }>();
@@ -64,6 +68,13 @@ export class TickMetricsAggregator {
     const toolTotals = new Map<string, { totalCalls: number; ticksUsed: number }>();
 
     for (const m of this.buffer) {
+      // The following three counters reflect what happened in the window
+      // regardless of success/failure — retries and aborts in errored ticks
+      // still occurred; queue depth at start is observed before the failure.
+      retriesSum += m.retries;
+      if (m.aborted) abortedCount++;
+      queueDepthAtStartSum += m.queueDepthAtStart;
+      if (m.queueDepthAtStart > queueDepthAtStartMax) queueDepthAtStartMax = m.queueDepthAtStart;
       if (m.errored) {
         // Errored ticks have partial timings — including them would skew the
         // success-path averages. Count them but exclude from timing/size sums.
@@ -127,6 +138,8 @@ export class TickMetricsAggregator {
       sampleCount: n,
       ignoredCount,
       erroredCount,
+      abortedCount,
+      retriesSum,
       avg: {
         totalMs: totalMs / avgDenom,
         llmMs: llmMs / avgDenom,
@@ -139,7 +152,10 @@ export class TickMetricsAggregator {
         historyChars: historyChars / avgDenom,
         toolCount: toolCount / avgDenom,
         contextContributors: contextContributors / avgDenom,
+        retries: retriesSum / n,
+        queueDepthAtStart: queueDepthAtStartSum / n,
       },
+      maxQueueDepthAtStart: queueDepthAtStartMax,
       pluginContextMs,
       toolsCalled,
     };
@@ -168,6 +184,10 @@ export interface TickMetricsSnapshot {
   ignoredCount: number;
   /** Number of ticks in the window that threw before completing. */
   erroredCount: number;
+  /** Number of ticks in the window whose AbortController fired before act() returned. */
+  abortedCount: number;
+  /** Total tool-retry attempts charged across the window (sum, not average). */
+  retriesSum: number;
   avg: {
     totalMs: number;
     llmMs: number;
@@ -180,7 +200,13 @@ export interface TickMetricsSnapshot {
     historyChars: number;
     toolCount: number;
     contextContributors: number;
+    /** Mean retries per tick across the window (includes errored ticks in the denominator). */
+    retries: number;
+    /** Mean combined queue depth at start across all ticks in the window. */
+    queueDepthAtStart: number;
   };
+  /** Largest combined queue depth observed at start of any tick in the window. */
+  maxQueueDepthAtStart: number;
   pluginContextMs: PluginAggregateRow[];
   /** Per-tool invocation totals across the window, sorted descending by totalCalls. */
   toolsCalled: ToolAggregateRow[];
@@ -190,6 +216,8 @@ const EMPTY_SNAPSHOT: TickMetricsSnapshot = {
   sampleCount: 0,
   ignoredCount: 0,
   erroredCount: 0,
+  abortedCount: 0,
+  retriesSum: 0,
   avg: {
     totalMs: 0,
     llmMs: 0,
@@ -202,7 +230,10 @@ const EMPTY_SNAPSHOT: TickMetricsSnapshot = {
     historyChars: 0,
     toolCount: 0,
     contextContributors: 0,
+    retries: 0,
+    queueDepthAtStart: 0,
   },
+  maxQueueDepthAtStart: 0,
   pluginContextMs: [],
   toolsCalled: [],
 };

--- a/packages/framework/src/core/types.ts
+++ b/packages/framework/src/core/types.ts
@@ -40,6 +40,20 @@ export interface AgentEventMap {
   "agent_yield": [reason: string | undefined, partialResult: string | undefined];
   /** Per-tick timing and size breakdown for performance analysis. Emitted at the end of each tick. */
   tick_metrics: [metrics: TickMetrics];
+  /**
+   * Emitted by tick() when it short-circuits because the agent is already
+   * mid-turn (isThinking=true) but the queues are non-empty — i.e. the input
+   * is waiting and will be processed when the current tick finishes. Lets UIs
+   * surface "your message is queued" without polling.
+   */
+  queued: [depth: { directDepth: number; ambientDepth: number }];
+  /**
+   * Emitted when the agent's base system prompt has been replaced at runtime
+   * via setSystemPrompt(). The payload is the prompt that will be used on the
+   * next tick — for CortexAgent this is the augmented version (directives
+   * already appended), not the raw value the caller passed in.
+   */
+  system_prompt_updated: [newSystemPrompt: string];
 }
 
 /**
@@ -82,6 +96,19 @@ export interface TickMetrics {
    * before the relevant stage ran.
    */
   errored: boolean;
+  /**
+   * Total tool-retry attempts charged during the tick. A tool that succeeds on
+   * its first try contributes 0; a tool with maxAttempts=3 that fails twice
+   * before succeeding contributes 2. Useful for spotting flaky tools / endpoints.
+   */
+  retries: number;
+  /** Whether the tick's AbortController fired before act() returned. */
+  aborted: boolean;
+  /**
+   * Combined queue depth (direct + ambient) observed when act() began. Lets
+   * observers distinguish "agent kept up with input" from "agent ran behind."
+   */
+  queueDepthAtStart: number;
 }
 
 /**


### PR DESCRIPTION
Extends BaseAgent + CortexAgent with the four remaining "small" items from the BaseAgent/CortexAgent audit improvement plan:

- F-25: TickMetrics gains retries / aborted / queueDepthAtStart; the aggregator surfaces them as sums, averages, and a max-queue-depth row.
- F-3: tick() emits a "queued" event when it short-circuits with non-empty queues so UIs can surface "your message is waiting" without polling.
- F-27: interrupt() returns Promise<void> resolving on the next idle emission; fire-and-forget callers are unaffected.
- F-22: setSystemPrompt() on both BaseAgent and CortexAgent (CortexAgent re-appends its three directives on every set), emits a system_prompt_updated event.

15 regression tests added under the existing "Audit fixes" sections.