### PR TITLE
Add zod-based structured output and migrate Episteme JSON features to it

### DIFF
--- a/packages/app-episteme/src/features/metadata.ts
+++ b/packages/app-episteme/src/features/metadata.ts
@@ -1,25 +1,29 @@
+import { z } from "zod";
 import { HeadlessAgent } from "@2b/framework/core/HeadlessAgent.ts";
 import { createProvider } from "@2b/framework/providers/llm/createProvider.ts";
 import type { EpistemeConfig } from "../config.ts";
 import { featureModel } from "../config.ts";
 
-const SYSTEM = `You are a document metadata generator. Given a document title and its opening content, return a JSON object with exactly these keys:
-- title: the document title (string)
-- tags: array of 3-6 relevant topic tags (lowercase, hyphenated strings)
-- date: today's ISO date as a string (YYYY-MM-DD)
-- summary: one sentence describing the document's purpose (string)
+const SYSTEM = `You are a document metadata generator. Given a document title and its opening content, produce its metadata:
+- title: the document title
+- tags: 3-6 relevant topic tags, lowercase and hyphenated
+- date: today's ISO date (YYYY-MM-DD)
+- summary: one sentence describing the document's purpose`;
 
-Return ONLY the raw JSON object — no markdown, no code fences, no explanation.
+/**
+ * Shape the metadata generator must return. Passed to `askStructured` so the
+ * model is constrained to this object (no fence-stripping or field guards) and
+ * the parsed result is runtime-validated. `tags` requires at least one entry;
+ * the prompt asks for 3-6.
+ */
+export const frontmatterSchema = z.object({
+  title: z.string(),
+  tags: z.array(z.string()).min(1),
+  date: z.string(),
+  summary: z.string(),
+});
 
-Example output:
-{"title":"Research on Cognitive Biases","tags":["psychology","cognitive-biases","decision-making"],"date":"2024-01-15","summary":"An exploration of common cognitive biases and their effects on decision-making."}`;
-
-interface FrontmatterData {
-  title: string;
-  tags: string[];
-  date: string;
-  summary: string;
-}
+export type FrontmatterData = z.infer<typeof frontmatterSchema>;
 
 export async function generateFrontmatter(
   title: string,
@@ -29,24 +33,19 @@ export async function generateFrontmatter(
   const today = new Date().toISOString().split("T")[0];
   const llm = createProvider(featureModel(config, "default"));
   const agent = new HeadlessAgent(llm, [], SYSTEM, { agentName: "MetadataGenerator" });
-  const raw = await agent.ask(
+
+  // askStructured constrains the model to frontmatterSchema and validates the
+  // result, so the fields below are guaranteed present and correctly typed.
+  const data = await agent.askStructured<FrontmatterData>(
     `Title: ${title}\nToday's date: ${today}\n\nDocument preview:\n${preview.slice(0, 500)}`,
+    frontmatterSchema,
   );
 
-  // Extract JSON — strip any accidental fences or surrounding text
-  const jsonMatch = raw.match(/\{[\s\S]*\}/);
-  if (!jsonMatch) throw new Error("Model did not return a JSON object");
-  const data: FrontmatterData = JSON.parse(jsonMatch[0]);
-
-  if (!data.title || !Array.isArray(data.tags) || !data.date || !data.summary) {
-    throw new Error("Model returned incomplete frontmatter fields");
-  }
-
   return [
-    `title: ${JSON.stringify(String(data.title))}`,
-    `tags: [${data.tags.map((t) => JSON.stringify(String(t))).join(", ")}]`,
-    `date: ${JSON.stringify(String(data.date))}`,
-    `summary: ${JSON.stringify(String(data.summary))}`,
+    `title: ${JSON.stringify(data.title)}`,
+    `tags: [${data.tags.map((t) => JSON.stringify(t)).join(", ")}]`,
+    `date: ${JSON.stringify(data.date)}`,
+    `summary: ${JSON.stringify(data.summary)}`,
   ].join("\n");
 }
 

--- a/packages/app-episteme/src/features/toc.ts
+++ b/packages/app-episteme/src/features/toc.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import { HeadlessAgent } from "@2b/framework/core/HeadlessAgent.ts";
 import { createProvider } from "@2b/framework/providers/llm/createProvider.ts";
 import type { EpistemeConfig } from "../config.ts";
@@ -20,11 +21,29 @@ export interface DocSection {
 
 const SYSTEM = `You are a document outliner. Given a list of document headings and their following text, generate a one-sentence description for each section.
 
-Return a JSON array where each element has:
-- "heading": the exact heading text
-- "description": a single sentence (max 15 words) describing what the section covers
+Return a "sections" list with one entry per input section, in the same order. Each entry has the exact heading text and a single sentence (max 15 words) describing what the section covers.`;
 
-Return ONLY the JSON array, no prose, no code fences.`;
+/**
+ * Shape of one TOC entry the model returns. Entries are aligned to the input
+ * sections by index, so the model must return one element per section in order
+ * (enforced at the mapping site, not here).
+ */
+export const tocItemSchema = z.object({
+  heading: z.string(),
+  description: z.string(),
+});
+
+/**
+ * The structured response. The array is wrapped in an object because local
+ * models reliably populate an object-rooted schema but tend to return `[]` for
+ * a top-level array under Ollama's `format`.
+ */
+export const tocResponseSchema = z.object({
+  sections: z.array(tocItemSchema),
+});
+
+export type TocItem = z.infer<typeof tocItemSchema>;
+export type TocResponse = z.infer<typeof tocResponseSchema>;
 
 export async function generateNarrativeToc(
   sections: DocSection[],
@@ -41,23 +60,21 @@ export async function generateNarrativeToc(
   }));
 
   try {
-    const raw = await agent.ask(
+    // Entries are aligned to `sections` by index; the model returns one item
+    // per section in order. On any parse/validation failure, fall back to
+    // description-less entries.
+    const { sections: items } = await agent.askStructured<TocResponse>(
       `Generate descriptions for these ${sections.length} sections:\n\n${JSON.stringify(input, null, 2)}`,
+      tocResponseSchema,
     );
-    const cleaned = raw.replace(/^```(?:json)?\n?/, "").replace(/\n?```$/, "").trim();
-    const parsed: unknown = JSON.parse(cleaned);
-    if (!Array.isArray(parsed)) return fallbackEntries(sections);
 
-    return sections.map((s, i) => {
-      const item = parsed[i] as { heading?: string; description?: string } | undefined;
-      return {
-        level: s.level,
-        text: s.heading,
-        description: item?.description?.trim() ?? "",
-        id: slugify(s.heading),
-        contentHash: sectionHash(s.heading, s.content),
-      };
-    });
+    return sections.map((s, i) => ({
+      level: s.level,
+      text: s.heading,
+      description: items[i]?.description?.trim() ?? "",
+      id: slugify(s.heading),
+      contentHash: sectionHash(s.heading, s.content),
+    }));
   } catch {
     return fallbackEntries(sections);
   }

--- a/packages/app-episteme/src/planning/PlanningController.ts
+++ b/packages/app-episteme/src/planning/PlanningController.ts
@@ -1,4 +1,5 @@
 import { randomUUID } from "node:crypto";
+import { z } from "zod";
 import { HeadlessAgent } from "@2b/framework/core/HeadlessAgent.ts";
 import type { LLMProvider } from "@2b/framework/providers/llm/LLMProvider.ts";
 import type { CortexAgent } from "@2b/framework/core/CortexAgent.ts";
@@ -14,18 +15,7 @@ import type {
 } from "./types.ts";
 
 const STRUCTURING_SYSTEM = `You are a planning assistant for Episteme, a Markdown research and writing tool.
-Given a user's goal, produce a structured JSON plan with ordered steps.
-
-Return ONLY valid JSON in this exact format, with no other text:
-{
-  "steps": [
-    {
-      "type": "research" | "outline" | "draft" | "edit" | "cite" | "analyze" | "organize",
-      "title": "short step title",
-      "instruction": "detailed instruction for this step"
-    }
-  ]
-}
+Given a user's goal, produce a plan as ordered steps. Each step has a type, a short title, and a detailed, self-contained instruction.
 
 Step types:
 - research: Find information, search sources, gather context from the workspace
@@ -44,18 +34,50 @@ Guidelines:
 const SUMMARIZE_SYSTEM = `You are a concise summarizer for a multi-step research and writing plan. Write 2-3 sentences capturing what was concretely accomplished. Prioritize: specific file paths created or modified, document titles or section headings produced, key decisions made, concrete numbers or named entities discovered, and any explicit outputs a later step should build on. Return only the summary, no preamble or labels.`;
 
 const STEP_GENERATOR_SYSTEM = `You are a planning assistant for Episteme, a Markdown research and writing tool.
-Given a plan goal, its existing steps, and a short description of a new step to add, generate a well-formed step object.
-
-Return ONLY valid JSON in this exact format, with no other text:
-{
-  "type": "research" | "outline" | "draft" | "edit" | "cite" | "analyze" | "organize",
-  "title": "short step title",
-  "instruction": "detailed, self-contained instruction for this step"
-}
-
+Given a plan goal, its existing steps, and a short description of a new step to add, generate a well-formed step with a type, a short title, and a detailed instruction.
+Valid types: research, outline, draft, edit, cite, analyze, organize.
 The instruction must be actionable and consistent with the surrounding steps in the plan.`;
 
-const VALID_STEP_TYPES = new Set<string>(["research", "outline", "draft", "edit", "cite", "analyze", "organize"]);
+/**
+ * Step types as a tuple kept exhaustively in lockstep with
+ * `EpistemePlanStepType`. The `Record<EpistemePlanStepType, true>` forces every
+ * union member to be listed (missing one is a compile error) and rejects any
+ * value that isn't a valid step type. `STEP_TYPES` then feeds `z.enum`, so the
+ * schema's `type` field is exactly `EpistemePlanStepType`.
+ */
+const STEP_TYPE_TABLE: Record<EpistemePlanStepType, true> = {
+  research: true,
+  outline: true,
+  draft: true,
+  edit: true,
+  cite: true,
+  analyze: true,
+  organize: true,
+};
+
+const STEP_TYPES = Object.keys(STEP_TYPE_TABLE) as [
+  EpistemePlanStepType,
+  ...EpistemePlanStepType[],
+];
+
+/**
+ * One plan step as the structurer/step-generator must return it. Used with
+ * `askStructured`: the enum replaces the `VALID_STEP_TYPES` coercion, and the
+ * model can no longer emit an unknown `type`.
+ */
+export const planStepSchema = z.object({
+  type: z.enum(STEP_TYPES),
+  title: z.string(),
+  instruction: z.string(),
+});
+
+/**
+ * Full structured-plan response. `.min(1)` enforces "at least one step" at
+ * parse time, replacing the manual `steps.length === 0` check.
+ */
+export const planSchema = z.object({
+  steps: z.array(planStepSchema).min(1),
+});
 
 const PRIOR_CONTEXT_RECENT_STEPS = 2;
 const PRIOR_CONTEXT_EXCERPT_CHARS = 800;
@@ -134,43 +156,30 @@ export class PlanningController {
     }
     prompt += "\n\nCreate a step-by-step plan.";
 
-    let raw: string;
+    // askStructured constrains the model to planSchema and validates the result:
+    // the enum guarantees a valid `type`, and `.min(1)` rejects an empty plan —
+    // so invalid JSON, a bad step type, and a step-less plan all surface here as
+    // a thrown error. Reset to idle and rethrow on any of them.
+    let parsed: z.infer<typeof planSchema>;
     try {
-      raw = await this.structurer.ask(prompt);
+      parsed = await this.structurer.askStructured(prompt, planSchema);
     } catch (err) {
       logger.error("PlanningController", `structuring failed: ${err}`);
       this.broadcast({ type: "state_change", state: "idle" });
       throw err;
     }
 
-    // Extract JSON — model may wrap it in markdown fences
-    const fenceMatch = raw.match(/```(?:json)?\s*([\s\S]*?)```/);
-    const jsonStr = fenceMatch ? fenceMatch[1] : raw;
-    let parsed: { steps?: Array<{ type?: string; title?: string; instruction?: string }> };
-    try {
-      parsed = JSON.parse(jsonStr ?? raw);
-    } catch {
-      logger.error("PlanningController", `invalid JSON from structurer: ${raw.slice(0, 300)}`);
-      this.broadcast({ type: "state_change", state: "idle" });
-      throw new Error("Plan structuring returned invalid JSON.");
-    }
-
     const planId = randomUUID();
     const now = Date.now();
-    const steps: EpistemePlanStep[] = (parsed.steps ?? []).map((s, i) => ({
+    const steps: EpistemePlanStep[] = parsed.steps.map((s, i) => ({
       id: randomUUID(),
       planId,
       index: i,
-      type: (VALID_STEP_TYPES.has(s.type ?? "") ? s.type : "research") as EpistemePlanStepType,
-      title: String(s.title ?? `Step ${i + 1}`),
-      instruction: String(s.instruction ?? ""),
+      type: s.type,
+      title: s.title,
+      instruction: s.instruction,
       state: "pending",
     }));
-
-    if (steps.length === 0) {
-      this.broadcast({ type: "state_change", state: "idle" });
-      throw new Error("Structuring produced no steps.");
-    }
 
     const plan: EpistemePlan = {
       id: planId,
@@ -297,22 +306,12 @@ export class PlanningController {
 
     const prompt = `Plan goal: ${plan.goal}\n\nExisting steps:\n${stepList}\n\nDescription for new step: ${description}${positionContext}\n\nGenerate a step object.`;
 
-    let raw: string;
+    let parsed: z.infer<typeof planStepSchema>;
     try {
-      raw = await this.stepGenerator.ask(prompt);
+      parsed = await this.stepGenerator.askStructured(prompt, planStepSchema);
     } catch (err) {
       logger.error("PlanningController", `addStep generation failed: ${err}`);
       throw err;
-    }
-
-    const fenceMatch = raw.match(/```(?:json)?\s*([\s\S]*?)```/);
-    const jsonStr = fenceMatch ? fenceMatch[1] : raw;
-    let parsed: { type?: string; title?: string; instruction?: string };
-    try {
-      parsed = JSON.parse(jsonStr ?? raw);
-    } catch {
-      logger.error("PlanningController", `addStep: invalid JSON: ${raw.slice(0, 200)}`);
-      throw new Error("Step generation returned invalid JSON.");
     }
 
     // Determine insertion index
@@ -330,9 +329,9 @@ export class PlanningController {
       id: randomUUID(),
       planId,
       index: insertIndex,
-      type: (VALID_STEP_TYPES.has(parsed.type ?? "") ? parsed.type : "research") as EpistemePlanStepType,
-      title: String(parsed.title ?? description.slice(0, 60)),
-      instruction: String(parsed.instruction ?? description),
+      type: parsed.type,
+      title: parsed.title,
+      instruction: parsed.instruction,
       state: "pending",
     };
 

--- a/packages/app-episteme/src/plugins/ContradictionPlugin.ts
+++ b/packages/app-episteme/src/plugins/ContradictionPlugin.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import type { AgentPlugin, ToolDefinition } from "@2b/framework/core/Plugin.ts";
 import type { BaseAgent } from "@2b/framework/core/BaseAgent.ts";
 import type { CortexMemoryPlugin } from "@2b/framework/plugins/CortexMemoryPlugin.ts";
@@ -19,13 +20,31 @@ A contradiction is when two statements assert directly opposing facts — not ju
 
 Given a numbered list of statements, identify pairs that DEFINITIVELY contradict each other.
 
-Respond with a JSON array:
-[
-  { "indexA": 0, "indexB": 2, "summary": "One sentence describing the contradiction" }
-]
+Return a "pairs" list. For each contradicting pair, give the two statement indices (indexA and indexB, matching the [N] numbers in the list) and a one-sentence summary of the contradiction. If no pairs contradict, return an empty pairs list.`;
 
-If no pairs contradict, return: []
-Return ONLY valid JSON. No preamble or markdown fences.`;
+/**
+ * One contradicting pair the scanner returns. `indexA`/`indexB` reference the
+ * numbered statements in the prompt; bounds against the current batch are still
+ * checked at the call site since the model can return out-of-range indices that
+ * the schema can't catch.
+ */
+export const contradictionPairSchema = z.object({
+  indexA: z.number().int(),
+  indexB: z.number().int(),
+  summary: z.string(),
+});
+
+/**
+ * The structured scan response. The array is wrapped in an object because local
+ * models reliably populate an object-rooted schema but tend to return `[]` for
+ * a top-level array under Ollama's `format`.
+ */
+export const contradictionScanSchema = z.object({
+  pairs: z.array(contradictionPairSchema),
+});
+
+export type ContradictionPair = z.infer<typeof contradictionPairSchema>;
+export type ContradictionScan = z.infer<typeof contradictionScanSchema>;
 
 export interface ContradictionRecord {
   id: string;
@@ -155,11 +174,13 @@ export class ContradictionPlugin implements AgentPlugin {
         .map((m, idx) => `[${idx}] ${m.text.replace(/\n+/g, " ").slice(0, 300)}`)
         .join("\n\n");
 
-      let pairs: Array<{ indexA: number; indexB: number; summary: string }> = [];
+      let pairs: ContradictionPair[] = [];
       try {
-        const raw = await this.getScannerAgent().ask(`Analyze for definite contradictions:\n\n${prompt}`);
-        const jsonMatch = raw.match(/\[[\s\S]*\]/);
-        if (jsonMatch) pairs = JSON.parse(jsonMatch[0]);
+        const scan = await this.getScannerAgent().askStructured<ContradictionScan>(
+          `Analyze for definite contradictions:\n\n${prompt}`,
+          contradictionScanSchema,
+        );
+        pairs = scan.pairs;
       } catch (err) {
         logger.warn(TAG, `Batch ${i} parse error: ${err}`);
         continue;

--- a/packages/app-episteme/src/plugins/style-guide/StyleGuideGenerator.test.ts
+++ b/packages/app-episteme/src/plugins/style-guide/StyleGuideGenerator.test.ts
@@ -1,51 +1,32 @@
 import { test, expect, describe } from "bun:test";
-import { parseTitleAndBody } from "./StyleGuideGenerator.ts";
+import { fallbackTitle, finalizeSection } from "./StyleGuideGenerator.ts";
 
-describe("parseTitleAndBody", () => {
-  test("splits a well-formed TITLE + body", () => {
-    const raw = "TITLE: Concise Voice\n\n- Use short sentences.\n- Cut filler.";
-    const { title, body } = parseTitleAndBody(raw);
-    expect(title).toBe("Concise Voice");
-    expect(body).toBe("- Use short sentences.\n- Cut filler.");
+describe("fallbackTitle", () => {
+  test("title-cases the first few words of the description", () => {
+    expect(fallbackTitle("punchy journalistic tone for blogs")).toBe("Punchy journalistic tone for");
   });
 
-  test("is case-insensitive on the TITLE label and tolerates leading blank lines", () => {
-    const raw = "\n\ntitle:   British English\n\nUse -our spellings.";
-    const { title, body } = parseTitleAndBody(raw);
-    expect(title).toBe("British English");
-    expect(body).toBe("Use -our spellings.");
+  test("returns Untitled for an empty description", () => {
+    expect(fallbackTitle("")).toBe("Untitled");
+    expect(fallbackTitle("   ")).toBe("Untitled");
+  });
+});
+
+describe("finalizeSection", () => {
+  test("trims the body and keeps a present title", () => {
+    const result = finalizeSection({ title: "Concise Voice", body: "\n- Use short sentences.\n" });
+    expect(result.title).toBe("Concise Voice");
+    expect(result.body).toBe("- Use short sentences.");
   });
 
-  test("strips a wrapping markdown fence", () => {
-    const raw = "```markdown\nTITLE: Coder Voice\n\nFormat code as `inline`.\n```";
-    const { title, body } = parseTitleAndBody(raw);
-    expect(title).toBe("Coder Voice");
-    expect(body).toBe("Format code as `inline`.");
+  test("substitutes a description-derived title when the model returns a blank one", () => {
+    const result = finalizeSection({ title: "   ", body: "Be brief." }, "terse");
+    expect(result.title).toBe("Terse");
+    expect(result.body).toBe("Be brief.");
   });
 
-  test("falls back to a derived title when TITLE is absent", () => {
-    const raw = "- Use active voice.\n- Prefer short sentences.";
-    const { title, body } = parseTitleAndBody(raw, "punchy journalistic tone for blogs");
-    expect(title).toBe("Punchy journalistic tone for");
-    expect(body).toBe("- Use active voice.\n- Prefer short sentences.");
-  });
-
-  test("uses the description fallback when TITLE value is empty", () => {
-    const raw = "TITLE:\n\nBe brief.";
-    const { title, body } = parseTitleAndBody(raw, "terse");
-    expect(title).toBe("Terse");
-    expect(body).toBe("Be brief.");
-  });
-
-  test("strips a leading placeholder line the model echoed verbatim", () => {
-    const raw = "TITLE: Approachability\n<blank line>\n\nWrite in a welcoming way.";
-    const { title, body } = parseTitleAndBody(raw);
-    expect(title).toBe("Approachability");
-    expect(body).toBe("Write in a welcoming way.");
-  });
-
-  test("defaults to Untitled with neither title nor description", () => {
-    const { title } = parseTitleAndBody("Body only.", "");
-    expect(title).toBe("Untitled");
+  test("falls back to Untitled when both title and description are empty", () => {
+    const result = finalizeSection({ title: "", body: "Body only." }, "");
+    expect(result.title).toBe("Untitled");
   });
 });

--- a/packages/app-episteme/src/plugins/style-guide/StyleGuideGenerator.ts
+++ b/packages/app-episteme/src/plugins/style-guide/StyleGuideGenerator.ts
@@ -1,3 +1,4 @@
+import { z } from "zod";
 import { HeadlessAgent } from "@2b/framework/core/HeadlessAgent.ts";
 import { createProvider } from "@2b/framework/providers/llm/createProvider.ts";
 import type { EpistemeConfig } from "../../config.ts";
@@ -5,9 +6,7 @@ import { featureModel } from "../../config.ts";
 
 const SYSTEM = `You write a single section of a writing style guide. The user gives a plain-language description of the style they want. Produce one focused section that an AI writing assistant can follow directly.
 
-Output format — output nothing else:
-- A first line of exactly "TITLE:" followed by a short title (1-4 words).
-- The remaining lines: the section body in raw Markdown.
+Produce a short title (1-4 words) and a body in raw Markdown.
 
 Rules for the body:
 - Imperative voice. "Use active verbs", never "active verbs should be used".
@@ -15,12 +14,20 @@ Rules for the body:
 - 80-250 words. Prefer a short intro line followed by a bullet list of rules.
 - Concrete and checkable. "Break any sentence over 25 words" beats "be concise".
 - No "you are..." preamble — the assistant already has an identity.
-- No commentary, no "here is", no code fences around the whole answer.`;
+- No commentary, no "here is".`;
 
-export interface GeneratedSection {
-  title: string;
-  body: string;
-}
+/**
+ * A generated style-guide section: a short `title` and a Markdown `body`.
+ * Used with `askStructured` to replace the `TITLE:`-line parsing — the model
+ * returns this object directly. Kept as `body` (not `content`) because
+ * StyleGuidePlugin consumes `.body`.
+ */
+export const generatedSectionSchema = z.object({
+  title: z.string(),
+  body: z.string(),
+});
+
+export type GeneratedSection = z.infer<typeof generatedSectionSchema>;
 
 /**
  * One-shot LLM generation of a style-guide section from a plain-language
@@ -43,32 +50,16 @@ export class StyleGuideGenerator {
   }
 
   async generate(description: string): Promise<GeneratedSection> {
-    const raw = await this.getAgent().ask(
+    const section = await this.getAgent().askStructured<GeneratedSection>(
       `Style description:\n${description.trim()}\n\nWrite the section now.`,
+      generatedSectionSchema,
     );
-    return parseTitleAndBody(raw, description);
+    return finalizeSection(section, description);
   }
 }
 
-/** Strip a code fence wrapping the whole answer, like AIFillPlugin does. */
-function stripWrappingFence(text: string): string {
-  const fenced = text.match(/^```(?:markdown|md)?\s*\n([\s\S]*?)\n```\s*$/i);
-  return fenced ? fenced[1]!.trim() : text;
-}
-
-/**
- * Drop leading lines that are a literal echo of a format placeholder. Smaller
- * models sometimes emit the prompt's structural hints (e.g. "<blank line>")
- * verbatim instead of acting on them.
- */
-function stripPlaceholderLines(body: string): string {
-  const lines = body.split("\n");
-  while (lines.length > 0 && /^\s*<[^>]+>\s*$/.test(lines[0]!)) lines.shift();
-  return lines.join("\n").trim();
-}
-
 /** Derive a fallback title from the description's first few words. */
-function fallbackTitle(description: string): string {
+export function fallbackTitle(description: string): string {
   const words = description.trim().split(/\s+/).filter(Boolean).slice(0, 4);
   if (words.length === 0) return "Untitled";
   const joined = words.join(" ");
@@ -76,26 +67,12 @@ function fallbackTitle(description: string): string {
 }
 
 /**
- * Parse the model output. Expects `TITLE: ...` on the first non-empty line,
- * then the body. Defends against a missing title and a wrapping fence. Exported
- * for unit testing.
+ * Tidy a validated section: trim the body and substitute a description-derived
+ * title when the model returned a blank one. Exported for unit testing.
  */
-export function parseTitleAndBody(raw: string, description = ""): GeneratedSection {
-  const cleaned = stripWrappingFence(raw.trim());
-  const lines = cleaned.split("\n");
-
-  // Find the first non-empty line; check it for a TITLE: prefix.
-  let i = 0;
-  while (i < lines.length && lines[i]!.trim() === "") i++;
-  const first = lines[i]?.trim() ?? "";
-  const match = first.match(/^TITLE:\s*(.*)$/i);
-
-  if (match) {
-    const title = match[1]!.trim() || fallbackTitle(description);
-    const body = stripPlaceholderLines(lines.slice(i + 1).join("\n").trim());
-    return { title, body: body || cleaned };
-  }
-
-  // No TITLE line — treat the whole thing as the body.
-  return { title: fallbackTitle(description), body: cleaned };
+export function finalizeSection(section: GeneratedSection, description = ""): GeneratedSection {
+  return {
+    title: section.title.trim() || fallbackTitle(description),
+    body: section.body.trim(),
+  };
 }

--- a/packages/framework/src/core/HeadlessAgent.test.ts
+++ b/packages/framework/src/core/HeadlessAgent.test.ts
@@ -1,7 +1,9 @@
 import { test, expect, describe, mock } from "bun:test";
+import { z } from "zod";
 import { HeadlessAgent } from "./HeadlessAgent";
 import type { AgentPlugin, ToolDefinition } from "./Plugin";
-import type { LLMProvider } from "../providers/llm/LLMProvider";
+import type { ChatResponse, LLMProvider } from "../providers/llm/LLMProvider";
+import { StructuredOutputError } from "../providers/llm/structuredOutput";
 import { AutoApprovePermissionManager, AutoDenyPermissionManager } from "./PermissionManager";
 
 // Minimal LLMProvider stub
@@ -316,5 +318,49 @@ describe("HeadlessAgent consecutive tool call circuit breaker", () => {
 
     expect(result).toBe("result"); // not an error — fresh counter
     expect(executeTool).toHaveBeenCalledTimes(5 + 1); // 5 from first ask + 1 from second
+  });
+});
+
+describe("HeadlessAgent.askStructured()", () => {
+  /** LLMProvider stub returning a controllable ChatResponse. */
+  function makeStructuredLLM(response: Partial<ChatResponse>): LLMProvider {
+    return {
+      chat: mock(async () => ({
+        response: "",
+        nonReasoningContent: "",
+        reasoningText: "",
+        ...response,
+      })),
+      getEmbedding: mock(async () => []),
+    } as unknown as LLMProvider;
+  }
+
+  const schema = z.object({ title: z.string(), count: z.number() });
+
+  test("forwards the schema to chat() as the third argument", async () => {
+    const llm = makeStructuredLLM({ parsed: { title: "T", count: 1 } });
+    const agent = new HeadlessAgent(llm, [], "base");
+    await agent.askStructured("task", schema);
+    expect((llm.chat as ReturnType<typeof mock>).mock.calls[0]![2]).toBe(schema);
+  });
+
+  test("returns the provider-parsed value when present", async () => {
+    const llm = makeStructuredLLM({ parsed: { title: "T", count: 2 } });
+    const agent = new HeadlessAgent(llm, [], "base");
+    const result = await agent.askStructured<z.infer<typeof schema>>("task", schema);
+    expect(result).toEqual({ title: "T", count: 2 });
+  });
+
+  test("falls back to parsing nonReasoningContent when the provider omits `parsed`", async () => {
+    const llm = makeStructuredLLM({ nonReasoningContent: '{"title":"X","count":3}' });
+    const agent = new HeadlessAgent(llm, [], "base");
+    const result = await agent.askStructured<z.infer<typeof schema>>("task", schema);
+    expect(result).toEqual({ title: "X", count: 3 });
+  });
+
+  test("throws StructuredOutputError when the fallback text fails validation", async () => {
+    const llm = makeStructuredLLM({ nonReasoningContent: '{"title":"X","count":"nope"}' });
+    const agent = new HeadlessAgent(llm, [], "base");
+    await expect(agent.askStructured("task", schema)).rejects.toThrow(StructuredOutputError);
   });
 });

--- a/packages/framework/src/core/HeadlessAgent.ts
+++ b/packages/framework/src/core/HeadlessAgent.ts
@@ -17,7 +17,8 @@
  * and for static sub-agents registered via SubAgentPlugin. Changes here affect
  * all spawned sub-agents.
  */
-import type { LLMProvider } from "../providers/llm/LLMProvider.ts";
+import type { ChatResponse, LLMProvider } from "../providers/llm/LLMProvider.ts";
+import { type StructuredSchema, parseStructured } from "../providers/llm/structuredOutput.ts";
 import type { AgentPlugin, ToolDefinition } from "./Plugin.ts";
 import type { Message } from "./types.ts";
 import { AutoDenyPermissionManager, type PermissionManager } from "./PermissionManager.ts";
@@ -74,7 +75,30 @@ export class HeadlessAgent {
     this.currentAbortController?.abort();
   }
 
+  /**
+   * Run the task and return the model's clean (non-reasoning) text response.
+   */
   async ask(task: string): Promise<string> {
+    return (await this.run(task)).nonReasoningContent;
+  }
+
+  /**
+   * Run the task constraining the model to `schema` and return the parsed,
+   * validated result. `schema` is a Zod schema (recommended — gives the return
+   * type and runtime validation) or a raw JSON Schema object.
+   *
+   * @throws {StructuredOutputError} if the model output can't be parsed as JSON
+   *   or fails Zod validation. Callers should keep their own fallback.
+   */
+  async askStructured<T>(task: string, schema: StructuredSchema): Promise<T> {
+    const response = await this.run(task, schema);
+    // Prefer the provider-parsed value; fall back to parsing the text ourselves
+    // for providers that honor `format` but don't populate `parsed`.
+    if (response.parsed !== undefined) return response.parsed as T;
+    return parseStructured<T>(response.nonReasoningContent, schema);
+  }
+
+  private async run(task: string, schema?: StructuredSchema): Promise<ChatResponse> {
     const agentName = this.options.agentName ?? "HeadlessAgent";
     // Fix #2: resolve once per ask() rather than allocating inside each tool
     // implementation closure, which would create a new instance per tool call.
@@ -166,8 +190,7 @@ export class HeadlessAgent {
 
     this.currentAbortController = new AbortController();
     try {
-      const { nonReasoningContent } = await this.llm.chat(messages, systemPrompt, undefined, tools, this.onToken, this.currentAbortController.signal);
-      return nonReasoningContent;
+      return await this.llm.chat(messages, systemPrompt, schema, tools, this.onToken, this.currentAbortController.signal);
     } finally {
       this.currentAbortController = null;
     }

--- a/packages/framework/src/providers/llm/LLMProvider.ts
+++ b/packages/framework/src/providers/llm/LLMProvider.ts
@@ -1,5 +1,6 @@
 import type { Message } from "../../core/types.ts";
 import type { ToolDefinition } from "../../core/Plugin.ts";
+import type { StructuredSchema } from "./structuredOutput.ts";
 
 /** The response returned by a single LLM `chat` call. */
 export interface ChatResponse {
@@ -18,6 +19,13 @@ export interface ChatResponse {
   nonReasoningContent: string;
   /** Raw reasoning / chain-of-thought text emitted by the model, if any. */
   reasoningText: string;
+  /**
+   * The parsed structured output, present only when a `schema` was supplied to
+   * `chat()` and the provider both honored it and parsed the result. Validated
+   * against the schema when the schema is a Zod schema. Callers that requested
+   * structured output should prefer this over re-parsing `nonReasoningContent`.
+   */
+  parsed?: unknown;
 }
 
 /**
@@ -31,9 +39,10 @@ export interface LLMProvider {
    * @param messages - Ordered conversation history.
    * @param systemPrompt - Optional system-level instruction prepended to the
    *   conversation.
-   * @param schema - Optional structured-output schema passed to the provider.
-   *   The concrete type is provider-specific; callers that do not need
-   *   structured output should pass `undefined`.
+   * @param schema - Optional structured-output schema. A Zod schema or a raw
+   *   JSON Schema object; providers constrain the model to this shape and
+   *   populate `ChatResponse.parsed`. Callers that do not need structured
+   *   output should pass `undefined`.
    * @param tools - Tool definitions the model may call during this turn.
    * @param onToken - Optional streaming callback invoked for each token as it
    *   is produced. `isReasoning` is `true` while the model is in its
@@ -42,7 +51,7 @@ export interface LLMProvider {
   chat(
     messages: Message[],
     systemPrompt?: string,
-    schema?: unknown,
+    schema?: StructuredSchema,
     tools?: ToolDefinition[],
     onToken?: (token: string, isReasoning: boolean) => void,
     abortSignal?: AbortSignal,

--- a/packages/framework/src/providers/llm/ModelCapabilityProvider.ts
+++ b/packages/framework/src/providers/llm/ModelCapabilityProvider.ts
@@ -14,6 +14,7 @@
 import type { LLMProvider, ChatResponse } from "./LLMProvider.ts";
 import type { ToolDefinition } from "../../core/Plugin.ts";
 import type { Message } from "../../core/types.ts";
+import type { StructuredSchema } from "./structuredOutput.ts";
 import { getModelCapabilities } from "./modelCapabilities.ts";
 
 type ProviderWithModelControl = LLMProvider & {
@@ -38,9 +39,10 @@ export class ModelCapabilityProvider implements LLMProvider {
   async chat(
     messages: Message[],
     systemPrompt?: string,
-    schema?: unknown,
+    schema?: StructuredSchema,
     tools?: ToolDefinition[],
     onToken?: (token: string, isReasoning: boolean) => void,
+    abortSignal?: AbortSignal,
   ): Promise<ChatResponse> {
     const { systemPromptPrefix } = getModelCapabilities(this.model);
     // Build the effective system prompt: prefix takes precedence over a missing
@@ -52,7 +54,7 @@ export class ModelCapabilityProvider implements LLMProvider {
           ? systemPromptPrefix
           : systemPrompt;
 
-    return this.inner.chat(messages, effectivePrompt, schema, tools, onToken);
+    return this.inner.chat(messages, effectivePrompt, schema, tools, onToken, abortSignal);
   }
 
   getEmbedding(text: string): Promise<number[]> {

--- a/packages/framework/src/providers/llm/OllamaProvider.test.ts
+++ b/packages/framework/src/providers/llm/OllamaProvider.test.ts
@@ -1,4 +1,6 @@
 import { test, expect, describe, mock, beforeEach } from "bun:test";
+import { z } from "zod";
+import { StructuredOutputError } from "./structuredOutput.ts";
 
 // ---------------------------------------------------------------------------
 // Module mock — must be declared before the import under test
@@ -471,6 +473,78 @@ describe("num_ctx option", () => {
     await provider.chat([{ role: "user", content: "hi" }], "");
     const opts = (mockChat.mock.calls[0]?.[0] as any).options;
     expect(opts).toBeUndefined();
+  });
+});
+
+describe("structured output", () => {
+  beforeEach(() => {
+    mockChat.mockClear?.();
+  });
+
+  test("format is omitted when no schema is given", async () => {
+    mockStreamChunks = [{ message: { content: "ok" }, done: true }];
+    const provider = makeProvider();
+    await provider.chat([{ role: "user", content: "hi" }], "");
+    expect((mockChat.mock.calls[0]?.[0] as any).format).toBeUndefined();
+  });
+
+  test("a Zod schema is sent as JSON Schema in `format` and the result is parsed and validated", async () => {
+    mockStreamChunks = [{ message: { content: '{"title":"T","count":3}' }, done: true }];
+    const schema = z.object({ title: z.string(), count: z.number() });
+    const provider = makeProvider();
+    const result = await provider.chat([{ role: "user", content: "hi" }], "", schema);
+
+    const sentFormat = (mockChat.mock.calls[0]?.[0] as any).format;
+    expect(sentFormat?.type).toBe("object");
+    expect(sentFormat?.properties?.title?.type).toBe("string");
+    expect(result.parsed).toEqual({ title: "T", count: 3 });
+    expect(result.nonReasoningContent).toBe('{"title":"T","count":3}');
+  });
+
+  test("a raw JSON Schema object is passed through unchanged as `format`", async () => {
+    mockStreamChunks = [{ message: { content: '{"x":1}' }, done: true }];
+    const rawSchema = { type: "object", properties: { x: { type: "number" } } };
+    const provider = makeProvider();
+    const result = await provider.chat([], "", rawSchema);
+    expect((mockChat.mock.calls[0]?.[0] as any).format).toEqual(rawSchema);
+    expect(result.parsed).toEqual({ x: 1 });
+  });
+
+  test("content that is not valid JSON throws StructuredOutputError", async () => {
+    mockStreamChunks = [{ message: { content: "not json" }, done: true }];
+    const provider = makeProvider();
+    await expect(
+      provider.chat([], "", z.object({ a: z.string() })),
+    ).rejects.toThrow(StructuredOutputError);
+  });
+
+  test("JSON that violates the schema throws StructuredOutputError", async () => {
+    mockStreamChunks = [{ message: { content: '{"a":123}' }, done: true }];
+    const provider = makeProvider();
+    await expect(
+      provider.chat([], "", z.object({ a: z.string() })),
+    ).rejects.toThrow(StructuredOutputError);
+  });
+
+  test("structured output through the tools path parses the final round", async () => {
+    const schema = z.object({ answer: z.string() });
+    const tools = [
+      { name: "noop", description: "x", parameters: { type: "object", properties: {} }, implementation: async () => "ok" },
+    ];
+    mockChat
+      .mockImplementationOnce(async () => streamOf({
+        role: "assistant",
+        content: "",
+        tool_calls: [{ function: { name: "noop", arguments: {} } }],
+      }))
+      .mockImplementationOnce(async () => streamOf({ role: "assistant", content: '{"answer":"42"}' }));
+
+    const provider = makeProvider();
+    const result = await provider.chat([], "", schema, tools as any);
+
+    // `format` is sent on every round, including tool-call rounds.
+    expect((mockChat.mock.calls[0]?.[0] as any).format?.type).toBe("object");
+    expect(result.parsed).toEqual({ answer: "42" });
   });
 });
 

--- a/packages/framework/src/providers/llm/OllamaProvider.ts
+++ b/packages/framework/src/providers/llm/OllamaProvider.ts
@@ -6,6 +6,7 @@ import {
 import type { LLMProvider, ChatResponse } from "./LLMProvider.ts";
 import type { ToolDefinition } from "../../core/Plugin.ts";
 import type { Message } from "../../core/types.ts";
+import { type StructuredSchema, toJsonSchema, parseStructured } from "./structuredOutput.ts";
 import { logger } from "../../logger.ts";
 
 export interface OllamaProviderOptions {
@@ -80,14 +81,14 @@ export class OllamaProvider implements LLMProvider {
   async chat(
     messages: Message[],
     systemPrompt: string = "",
-    _schema?: unknown,
+    schema?: StructuredSchema,
     tools?: ToolDefinition[],
     onToken?: (token: string, isReasoning: boolean) => void,
     abortSignal?: AbortSignal,
   ): Promise<ChatResponse> {
     logger.info(
       "Ollama",
-      `chat() model=${this.model} tools=${tools?.length ?? 0} messages=${messages.length}`,
+      `chat() model=${this.model} tools=${tools?.length ?? 0} messages=${messages.length} structured=${schema !== undefined}`,
     );
 
     try {
@@ -116,10 +117,11 @@ export class OllamaProvider implements LLMProvider {
           tools,
           onToken,
           abortSignal,
+          schema,
         );
       }
 
-      return await this.respond(ollamaMessages, onToken, abortSignal);
+      return await this.respond(ollamaMessages, onToken, abortSignal, schema);
     } catch (error) {
       logger.error("Ollama", "Error communicating with Ollama server:", error);
       throw error;
@@ -160,15 +162,22 @@ export class OllamaProvider implements LLMProvider {
     messages: OllamaMessage[],
     onToken?: (token: string, isReasoning: boolean) => void,
     abortSignal?: AbortSignal,
+    schema?: StructuredSchema,
   ): Promise<ChatResponse> {
     let reasoningText = "";
     let responseContent = "";
+
+    // When a schema is supplied, Ollama's `format` constrains `message.content`
+    // to JSON matching the schema. Streaming still fires per-token, but the
+    // accumulated content is the JSON object — parsed into `parsed` below.
+    const format = schema !== undefined ? toJsonSchema(schema) : undefined;
 
     const stream = await this.withThinkFallback((think) =>
       this.client.chat({
         model: this.model,
         messages,
         stream: true,
+        ...(format !== undefined ? { format } : {}),
         ...(think !== undefined ? { think } : {}),
         ...(this.numCtx !== undefined
           ? { options: { num_ctx: this.numCtx } }
@@ -194,6 +203,9 @@ export class OllamaProvider implements LLMProvider {
       response: responseContent || reasoningText,
       nonReasoningContent: responseContent,
       reasoningText,
+      ...(schema !== undefined
+        ? { parsed: parseStructured(responseContent, schema) }
+        : {}),
     };
   }
 
@@ -203,10 +215,18 @@ export class OllamaProvider implements LLMProvider {
     tools: ToolDefinition[],
     onToken?: (token: string, isReasoning: boolean) => void,
     abortSignal?: AbortSignal,
+    schema?: StructuredSchema,
   ): Promise<ChatResponse> {
     const MAX_ROUNDS = 100;
     const toolMap = new Map(tools.map((t) => [t.name, t]));
     const history = [...messages];
+
+    // Structured output combined with tools is best-effort: `format` is sent on
+    // every round, so tool-call rounds emit `tool_calls` (no content) while the
+    // final answer round emits schema-conforming JSON content (parsed below).
+    // Small local models may not reliably combine the two — the dependable path
+    // is structured output without tools (see respond()).
+    const format = schema !== undefined ? toJsonSchema(schema) : undefined;
 
     // Mirror abort state in a local flag via event listener.
     // In Bun's runtime, abortSignal.aborted may not reflect synchronously across
@@ -232,6 +252,7 @@ export class OllamaProvider implements LLMProvider {
             messages: history,
             tools: ollamaTools,
             stream: true,
+            ...(format !== undefined ? { format } : {}),
             ...(think !== undefined ? { think } : {}),
             ...(this.numCtx !== undefined
               ? { options: { num_ctx: this.numCtx } }
@@ -269,6 +290,9 @@ export class OllamaProvider implements LLMProvider {
             response: roundContent || roundThinking,
             nonReasoningContent: roundContent,
             reasoningText: roundThinking,
+            ...(schema !== undefined
+              ? { parsed: parseStructured(roundContent, schema) }
+              : {}),
           };
         }
 

--- a/packages/framework/src/providers/llm/structuredOutput.test.ts
+++ b/packages/framework/src/providers/llm/structuredOutput.test.ts
@@ -1,0 +1,80 @@
+import { test, expect, describe } from "bun:test";
+import { z } from "zod";
+import {
+  StructuredOutputError,
+  isZodSchema,
+  toJsonSchema,
+  parseStructured,
+} from "./structuredOutput.ts";
+
+describe("isZodSchema", () => {
+  test("true for a Zod schema", () => {
+    expect(isZodSchema(z.object({ a: z.string() }))).toBe(true);
+  });
+
+  test("false for a raw JSON Schema object", () => {
+    expect(isZodSchema({ type: "object", properties: {} })).toBe(false);
+  });
+});
+
+describe("toJsonSchema", () => {
+  test("converts a Zod schema to JSON Schema", () => {
+    const json = toJsonSchema(z.object({ name: z.string(), n: z.number() })) as any;
+    expect(json.type).toBe("object");
+    expect(json.properties.name.type).toBe("string");
+    expect(json.required).toContain("name");
+  });
+
+  test("passes a raw JSON Schema object through unchanged", () => {
+    const raw = { type: "object", properties: { x: { type: "number" } } };
+    expect(toJsonSchema(raw)).toBe(raw);
+  });
+});
+
+describe("parseStructured", () => {
+  test("parses and validates against a Zod schema, returning typed data", () => {
+    const schema = z.object({ title: z.string(), tags: z.array(z.string()) });
+    const result = parseStructured('{"title":"X","tags":["a","b"]}', schema);
+    expect(result).toEqual({ title: "X", tags: ["a", "b"] });
+  });
+
+  test("tolerates surrounding whitespace", () => {
+    const result = parseStructured('  \n {"a":1}\n ', z.object({ a: z.number() }));
+    expect(result).toEqual({ a: 1 });
+  });
+
+  test("returns the parsed value as-is when no schema is supplied", () => {
+    const result = parseStructured<{ a: number }>('{"a":1}');
+    expect(result).toEqual({ a: 1 });
+  });
+
+  test("does not validate when given a raw JSON Schema (no runtime check)", () => {
+    // Raw JSON Schema can't validate here — the value is returned untouched even
+    // though it doesn't match the declared shape.
+    const result = parseStructured('{"a":"wrong-type"}', {
+      type: "object",
+      properties: { a: { type: "number" } },
+    });
+    expect(result).toEqual({ a: "wrong-type" });
+  });
+
+  test("throws StructuredOutputError on invalid JSON, carrying the raw text", () => {
+    try {
+      parseStructured("not json", z.object({ a: z.string() }));
+      throw new Error("expected throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(StructuredOutputError);
+      expect((e as StructuredOutputError).raw).toBe("not json");
+    }
+  });
+
+  test("throws StructuredOutputError when the value fails Zod validation", () => {
+    try {
+      parseStructured('{"a":123}', z.object({ a: z.string() }));
+      throw new Error("expected throw");
+    } catch (e) {
+      expect(e).toBeInstanceOf(StructuredOutputError);
+      expect((e as StructuredOutputError).raw).toBe('{"a":123}');
+    }
+  });
+});

--- a/packages/framework/src/providers/llm/structuredOutput.ts
+++ b/packages/framework/src/providers/llm/structuredOutput.ts
@@ -1,0 +1,85 @@
+/**
+ * Structured-output helpers shared by LLM providers and agents.
+ *
+ * A `StructuredSchema` is either a Zod schema (preferred — gives compile-time
+ * types and runtime validation) or a raw JSON Schema object (escape hatch for
+ * ad-hoc shapes). `toJsonSchema` normalizes either into the JSON Schema that
+ * providers send to the model (e.g. Ollama's `format`), and `parseStructured`
+ * turns the model's JSON text back into a typed, validated value.
+ */
+import { z } from "zod";
+
+/** A Zod schema or a raw JSON Schema object describing the desired output. */
+export type StructuredSchema = z.ZodType | Record<string, unknown>;
+
+/**
+ * Thrown when a model's structured output can't be parsed as JSON or fails
+ * validation against the supplied Zod schema. Carries the raw model text so
+ * callers can log or fall back.
+ */
+export class StructuredOutputError extends Error {
+  constructor(
+    message: string,
+    /** The raw model output that failed to parse/validate. */
+    public readonly raw: string,
+    /** The underlying JSON.parse or Zod error, if any. */
+    public override readonly cause?: unknown,
+  ) {
+    super(message);
+    this.name = "StructuredOutputError";
+  }
+}
+
+/** True when the value is a Zod schema rather than a raw JSON Schema object. */
+export function isZodSchema(schema: StructuredSchema): schema is z.ZodType {
+  return schema instanceof z.ZodType;
+}
+
+/**
+ * Convert a `StructuredSchema` to a JSON Schema object suitable for a provider's
+ * structured-output request. Zod schemas are converted via `z.toJSONSchema`;
+ * raw JSON Schema objects are passed through unchanged.
+ */
+export function toJsonSchema(schema: StructuredSchema): object {
+  return isZodSchema(schema) ? z.toJSONSchema(schema) : schema;
+}
+
+/**
+ * Parse model output text into a typed value.
+ *
+ * - Always `JSON.parse`s the (trimmed) text — providers using structured output
+ *   return raw JSON, so no fence-stripping is performed here.
+ * - When `schema` is a Zod schema, the parsed value is validated and the typed
+ *   `data` is returned.
+ * - When `schema` is a raw JSON Schema (or omitted), the parsed value is
+ *   returned as-is cast to `T` (no runtime validation).
+ *
+ * @throws {StructuredOutputError} if the text is not valid JSON or fails Zod
+ *   validation.
+ */
+export function parseStructured<T>(text: string, schema?: StructuredSchema): T {
+  let value: unknown;
+  try {
+    value = JSON.parse(text.trim());
+  } catch (cause) {
+    throw new StructuredOutputError(
+      `Structured output was not valid JSON: ${cause instanceof Error ? cause.message : String(cause)}`,
+      text,
+      cause,
+    );
+  }
+
+  if (schema && isZodSchema(schema)) {
+    const result = schema.safeParse(value);
+    if (!result.success) {
+      throw new StructuredOutputError(
+        `Structured output failed schema validation: ${result.error.message}`,
+        text,
+        result.error,
+      );
+    }
+    return result.data as T;
+  }
+
+  return value as T;
+}


### PR DESCRIPTION
Introduce a provider-level structured-output capability and route every Episteme feature that produced JSON through it, replacing per-site regex/JSON.parse/field-guard parsing with schema-validated results.

Framework foundation:
- structuredOutput.ts: StructuredSchema (Zod schema | raw JSON Schema), toJsonSchema() (Zod -> JSON Schema via z.toJSONSchema, raw passed through), parseStructured<T>() (JSON.parse + Zod validation), and StructuredOutputError carrying the raw model text.
- LLMProvider: retype chat()'s `schema` param from `unknown` to StructuredSchema and add optional `parsed` to ChatResponse (backward compatible).
- OllamaProvider: honor `schema` by sending Ollama's `format` (the JSON Schema) and populating `parsed`. Applied in both the no-tools path and every round of the tool-call loop (parsed on the final round). Omitting `schema` leaves output as normal text.
- HeadlessAgent: extract the shared body into run(); ask() stays a thin wrapper; add askStructured<T>(task, schema) returning the typed, validated object (prefers provider `parsed`, falls back to parsing nonReasoningContent).
- ModelCapabilityProvider: forward the previously-dropped abortSignal.

Episteme migrations (all six structured-output sites):
- features/metadata.ts: frontmatterSchema
- features/toc.ts: tocResponseSchema, object-wrapped as { sections: [...] }
- planning/PlanningController.ts: planSchema (structurePlan) and planStepSchema (addStep); enum replaces VALID_STEP_TYPES coercion, .min(1) replaces the empty-steps check; dead VALID_STEP_TYPES removed.
- plugins/ContradictionPlugin.ts: contradictionScanSchema, object-wrapped as { pairs: [...] }
- plugins/style-guide/StyleGuideGenerator.ts: generatedSectionSchema; the TITLE:-line parser and fence/placeholder strippers are replaced by finalizeSection() + fallbackTitle(). Each site drops its "Return ONLY valid JSON ..." prompt boilerplate (the schema enforces shape) and keeps its existing failure handling.

Notes:
- Top-level array schemas are object-wrapped because local models reliably populate an object root but return [] for a bare top-level array under Ollama format.
- The literal `format: "json"` (loose JSON, no schema) mode is intentionally not exposed; only text and specific-schema modes are supported.

Tests: unit coverage for structuredOutput, OllamaProvider `format` wiring, and HeadlessAgent.askStructured; StyleGuideGenerator tests updated for the new finalizeSection/fallbackTitle helpers. Live-verified end to end on a structured-output-capable local model (all six shapes returned valid objects).